### PR TITLE
fix: optimize mobile ranking row layout

### DIFF
--- a/web/src/components/RankingTable.tsx
+++ b/web/src/components/RankingTable.tsx
@@ -13,15 +13,15 @@ export function RankingTable({ islands }: Props) {
       <colgroup>
         <col style={{ width: 48 }} />
         <col style={{ width: '50%' }} />
-        <col style={{ width: 260 }} />
-        <col style={{ width: 260 }} />
+        <col style={{ width: 260 }} className="id-col" />
+        <col style={{ width: 260 }} className="creator-col" />
       </colgroup>
       <thead className="bg-gray-50">
         <tr>
           <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
           <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Island</th>
-          <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-          <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Creator</th>
+          <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider id-col">ID</th>
+          <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider creator-col">Creator</th>
         </tr>
       </thead>
       <tbody className="bg-white divide-y divide-gray-200">
@@ -31,6 +31,10 @@ export function RankingTable({ islands }: Props) {
             <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 island-cell">
               <Link to={`/island/${island.code}?name=${encodeURIComponent(island.name)}`} className="hover:underline">
                 <span className="island-name">{island.name}</span>
+                <span className="island-meta mobile-only">
+                  {island.code}
+                  {island.creator ? ` · ${island.creator}` : ''}
+                </span>
               </Link>
             </td>
             <td className="px-6 py-4 text-sm text-gray-500 island-code id-cell" title={island.code}>
@@ -44,7 +48,7 @@ export function RankingTable({ islands }: Props) {
                 📋
               </button>
             </td>
-            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 island-creator" title={island.creator}>{island.creator}</td>
+            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 island-creator creator-cell" title={island.creator}>{island.creator}</td>
           </tr>
         ))}
       </tbody>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -50,6 +50,7 @@ input { padding: 6px 10px; border-radius: 8px; border: 1px solid #e5e7eb33; back
 .island-creator { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .id-text { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
 .copy-btn { flex: 0 0 auto; border: 1px solid #e5e7eb66; background: transparent; width: 22px; height: 22px; border-radius: 6px; cursor: pointer; font-size: 14px; line-height: 1; display:inline-flex; align-items:center; justify-content:center; }
+.mobile-only { display: none; }
 
 /* Loading indicator */
 .loading-row { display:flex; align-items:center; gap:8px; }
@@ -63,5 +64,11 @@ input { padding: 6px 10px; border-radius: 8px; border: 1px solid #e5e7eb33; back
 
 /* table layout fixed for ellipsis */
 .islands-table { table-layout: fixed; width: 100%; }
+
+@media (max-width: 640px) {
+  .mobile-only { display: block; margin-left: 0; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .id-col, .creator-col { width: 0 !important; }
+  .id-cell, .creator-cell, th.id-col, th.creator-col { display: none; }
+}
 
 


### PR DESCRIPTION
## Summary
- avoid island name overlapping ID by hiding ID/creator columns on small screens
- show island ID and creator beneath the island name on mobile

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d3312de68832f8bb195b5301cac63