### PR TITLE
feat(web): add v2 frontend foundation

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite --port 5173",
     "build": "tsc -b && vite build",
-    "preview": "vite preview --port 5173"
+    "preview": "vite preview --port 5173",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "dayjs": "^1.11.13",
@@ -21,11 +23,14 @@
     "swr": "^2.2.5"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.7.0",
+    "@testing-library/react": "^16.3.0",
     "@types/react": "^18.3.8",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
+    "jsdom": "^26.0.0",
     "typescript": "^5.5.4",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vitest": "^3.2.4"
   }
 }
-

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,37 +1,87 @@
-import type { Island, MetricPoint, TimeWindow } from './types';
+import type {
+  CompareResponse,
+  DashboardRequest,
+  DashboardResponse,
+  Island,
+  IslandOverviewResponse,
+  IslandsSearchParams,
+  MetricSeries,
+  Research,
+  TimeWindow
+} from './types';
 
-export async function fetchIslands(params: { window: TimeWindow; query?: string; category?: string; limit?: number; sort?: string }): Promise<Island[]> {
-  const url = new URL('/api/islands', location.origin);
-  Object.entries(params).forEach(([k, v]) => {
-    if (v !== undefined && v !== '') url.searchParams.set(k, String(v));
-  });
-  const res = await fetch(url.toString());
-  if (!res.ok) throw new Error(`Failed: ${res.status}`);
-  return res.json();
+export type { Research } from './types';
+
+type QueryValue = string | number | boolean | undefined | null | string[];
+
+function getBaseOrigin() {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin;
+  }
+  return 'http://localhost';
 }
 
-export type Research = {
-  summary: string;
-  highlights?: string[];
-  sources?: { title?: string; url: string }[];
-  updatedAt: string;
-};
+function buildUrl(pathname: string, query?: Record<string, QueryValue>) {
+  const url = new URL(pathname, getBaseOrigin());
+
+  if (!query) return url;
+
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null || value === '') continue;
+
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        url.searchParams.set(key, value.join(','));
+      }
+      continue;
+    }
+
+    url.searchParams.set(key, String(value));
+  }
+
+  return url;
+}
+
+async function fetchJson<T>(pathname: string, query?: Record<string, QueryValue>): Promise<T> {
+  const response = await fetch(buildUrl(pathname, query).toString());
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(body || `Failed: ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function fetchIslands(params: IslandsSearchParams): Promise<Island[]> {
+  return fetchJson<Island[]>('/api/islands', params);
+}
+
+export async function fetchDashboard(params: DashboardRequest): Promise<DashboardResponse> {
+  return fetchJson<DashboardResponse>('/api/dashboard', {
+    window: params.window,
+    sort: params.sort,
+    tags: params.tags,
+    creator: params.creator
+  });
+}
+
+export async function fetchIslandOverview(code: string, window: TimeWindow): Promise<IslandOverviewResponse> {
+  return fetchJson<IslandOverviewResponse>(`/api/islands/${code}/overview`, { window });
+}
+
+export async function fetchCompare(codes: string[], window: TimeWindow): Promise<CompareResponse> {
+  return fetchJson<CompareResponse>('/api/compare', {
+    window,
+    codes
+  });
+}
 
 export async function fetchIslandResearch(code: string, name?: string, lang?: string): Promise<Research> {
-  const url = new URL(`/api/islands/${code}/research`, location.origin);
-  if (name) url.searchParams.set('name', name);
-  if (lang) url.searchParams.set('lang', lang);
-  const res = await fetch(url.toString());
-  if (!res.ok) throw new Error(`Failed: ${res.status}`);
-  return res.json();
+  return fetchJson<Research>(`/api/islands/${code}/research`, {
+    name,
+    lang
+  });
 }
 
-export async function fetchIslandMetrics(code: string, window: TimeWindow): Promise<{ metric: string; points: MetricPoint[] }[]> {
-  const url = new URL(`/api/islands/${code}/metrics`, location.origin);
-  url.searchParams.set('window', window);
-  const res = await fetch(url.toString());
-  if (!res.ok) throw new Error(`Failed: ${res.status}`);
-  return res.json();
+export async function fetchIslandMetrics(code: string, window: TimeWindow): Promise<MetricSeries[]> {
+  return fetchJson<MetricSeries[]>(`/api/islands/${code}/metrics`, { window });
 }
-
-

--- a/web/src/lib/storage.test.ts
+++ b/web/src/lib/storage.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clearCompareDraft,
+  isWatchlisted,
+  pushRecentSearch,
+  pushRecentView,
+  readCompareDraft,
+  readRecentSearches,
+  readRecentViews,
+  readWatchlist,
+  removeWatchlist,
+  upsertWatchlist,
+  writeCompareDraft
+} from './storage';
+
+describe('storage', () => {
+  it('persists compare draft with deduped codes', () => {
+    writeCompareDraft(['1111', '2222', '2222', '3333', '4444', '5555']);
+
+    expect(readCompareDraft()).toMatchObject({
+      codes: ['1111', '2222', '3333', '4444']
+    });
+
+    clearCompareDraft();
+    expect(readCompareDraft()).toBeNull();
+  });
+
+  it('keeps watchlist in reverse chronological order and removes items', () => {
+    upsertWatchlist({ code: '1111', name: 'Alpha', creator: 'Studio A' });
+    upsertWatchlist({ code: '2222', name: 'Beta', creator: 'Studio B' });
+
+    expect(readWatchlist().map((entry) => entry.code)).toEqual(['2222', '1111']);
+    expect(isWatchlisted('1111')).toBe(true);
+
+    removeWatchlist('1111');
+    expect(readWatchlist().map((entry) => entry.code)).toEqual(['2222']);
+    expect(isWatchlisted('1111')).toBe(false);
+  });
+
+  it('dedupes and caps recent searches', () => {
+    pushRecentSearch('box');
+    pushRecentSearch('zone');
+    pushRecentSearch('box');
+
+    expect(readRecentSearches().map((entry) => entry.query)).toEqual(['box', 'zone']);
+  });
+
+  it('dedupes recent views by code and keeps the most recent first', () => {
+    pushRecentView({ code: '1111', name: 'Alpha', creator: 'Studio A', window: '10m' });
+    pushRecentView({ code: '2222', name: 'Beta', creator: 'Studio B', window: '1h' });
+    pushRecentView({ code: '1111', name: 'Alpha', creator: 'Studio A', window: '24h' });
+
+    expect(readRecentViews()).toEqual([
+      expect.objectContaining({ code: '1111', window: '24h' }),
+      expect.objectContaining({ code: '2222', window: '1h' })
+    ]);
+  });
+});

--- a/web/src/lib/storage.ts
+++ b/web/src/lib/storage.ts
@@ -1,0 +1,146 @@
+import type {
+  CompareDraft,
+  RecentSearchEntry,
+  RecentViewEntry,
+  TimeWindow,
+  WatchlistEntry
+} from './types';
+
+const STORAGE_KEYS = {
+  compareDraft: 'fortnite.compareDraft',
+  watchlist: 'fortnite.watchlist',
+  recentSearches: 'fortnite.recentSearches',
+  recentViews: 'fortnite.recentViews'
+} as const;
+
+const WATCHLIST_LIMIT = 30;
+const RECENT_SEARCH_LIMIT = 8;
+const RECENT_VIEW_LIMIT = 8;
+
+function canUseStorage() {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function readJson<T>(key: string, fallback: T): T {
+  if (!canUseStorage()) return fallback;
+
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function writeJson<T>(key: string, value: T) {
+  if (!canUseStorage()) return;
+  window.localStorage.setItem(key, JSON.stringify(value));
+}
+
+function sanitizeCodes(codes: string[]) {
+  return [...new Set(codes.map((code) => code.trim()).filter(Boolean))].slice(0, 4);
+}
+
+export function readCompareDraft(): CompareDraft | null {
+  const stored = readJson<CompareDraft | null>(STORAGE_KEYS.compareDraft, null);
+  if (!stored) return null;
+
+  return {
+    codes: sanitizeCodes(stored.codes ?? []),
+    updatedAt: stored.updatedAt ?? new Date(0).toISOString()
+  };
+}
+
+export function writeCompareDraft(codes: string[]) {
+  const draft: CompareDraft = {
+    codes: sanitizeCodes(codes),
+    updatedAt: new Date().toISOString()
+  };
+  writeJson(STORAGE_KEYS.compareDraft, draft);
+  return draft;
+}
+
+export function clearCompareDraft() {
+  if (!canUseStorage()) return;
+  window.localStorage.removeItem(STORAGE_KEYS.compareDraft);
+}
+
+export function readWatchlist(): WatchlistEntry[] {
+  return readJson<WatchlistEntry[]>(STORAGE_KEYS.watchlist, []).filter((entry) => Boolean(entry.code));
+}
+
+export function saveWatchlist(entries: WatchlistEntry[]) {
+  const deduped = new Map<string, WatchlistEntry>();
+  for (const entry of entries) {
+    if (!entry.code) continue;
+    deduped.set(entry.code, { ...entry, savedAt: entry.savedAt ?? new Date().toISOString() });
+  }
+  const ordered = [...deduped.values()]
+    .sort((left, right) => right.savedAt.localeCompare(left.savedAt))
+    .slice(0, WATCHLIST_LIMIT);
+
+  writeJson(STORAGE_KEYS.watchlist, ordered);
+  return ordered;
+}
+
+export function upsertWatchlist(entry: Omit<WatchlistEntry, 'savedAt'>) {
+  const existing = readWatchlist().filter((item) => item.code !== entry.code);
+  return saveWatchlist([{ ...entry, savedAt: new Date().toISOString() }, ...existing]);
+}
+
+export function removeWatchlist(code: string) {
+  return saveWatchlist(readWatchlist().filter((entry) => entry.code !== code));
+}
+
+export function isWatchlisted(code: string) {
+  return readWatchlist().some((entry) => entry.code === code);
+}
+
+export function readRecentSearches(): RecentSearchEntry[] {
+  return readJson<RecentSearchEntry[]>(STORAGE_KEYS.recentSearches, []).filter((entry) => Boolean(entry.query));
+}
+
+export function pushRecentSearch(query: string) {
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery) return readRecentSearches();
+
+  const entries = [
+    { query: normalizedQuery, usedAt: new Date().toISOString() },
+    ...readRecentSearches().filter((entry) => entry.query !== normalizedQuery)
+  ].slice(0, RECENT_SEARCH_LIMIT);
+
+  writeJson(STORAGE_KEYS.recentSearches, entries);
+  return entries;
+}
+
+export function clearRecentSearches() {
+  if (!canUseStorage()) return;
+  window.localStorage.removeItem(STORAGE_KEYS.recentSearches);
+}
+
+export function readRecentViews(): RecentViewEntry[] {
+  return readJson<RecentViewEntry[]>(STORAGE_KEYS.recentViews, []).filter((entry) => Boolean(entry.code));
+}
+
+export function pushRecentView(entry: Omit<RecentViewEntry, 'viewedAt'> & { window?: TimeWindow }) {
+  const normalized: RecentViewEntry = {
+    ...entry,
+    window: entry.window ?? '10m',
+    viewedAt: new Date().toISOString()
+  };
+
+  const entries = [
+    normalized,
+    ...readRecentViews().filter((item) => item.code !== normalized.code)
+  ].slice(0, RECENT_VIEW_LIMIT);
+
+  writeJson(STORAGE_KEYS.recentViews, entries);
+  return entries;
+}
+
+export function clearRecentViews() {
+  if (!canUseStorage()) return;
+  window.localStorage.removeItem(STORAGE_KEYS.recentViews);
+}
+
+export const storageKeys = STORAGE_KEYS;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,30 +1,227 @@
 export type TimeWindow = '10m' | '1h' | '24h';
 
+export type DashboardTab = 'top' | 'rising';
+export type DashboardView = 'table' | 'cards';
+export type DashboardSort =
+  | 'hype'
+  | 'uniquePlayers'
+  | 'peakCcu'
+  | 'minutesPerPlayer'
+  | 'retentionD1'
+  | 'recommends'
+  | 'favorites'
+  | 'latestChange';
+
+export type TrendDirection = 'up' | 'down' | 'flat' | 'unknown';
+
+export type IslandMetricName =
+  | 'uniquePlayers'
+  | 'peakCcu'
+  | 'minutesPerPlayer'
+  | 'retentionD1'
+  | 'retentionD7'
+  | 'recommends'
+  | 'favorites'
+  | 'plays'
+  | 'minutesPlayed';
+
 export type Island = {
   code: string;
   name: string;
   creator: string;
-  tags?: string[];
+  tags: string[];
 };
 
-export type RankedIsland = Island & {
+export type MetricPoint = {
+  ts: string;
+  value: number | null;
+};
+
+export type MetricSeries = {
+  metric: IslandMetricName | string;
+  points: MetricPoint[];
+};
+
+export type HypeScoreComponent = {
+  metric: IslandMetricName | string;
+  label: string;
+  weight: number;
+  appliedWeight: number;
+  normalizedValue: number | null;
+  contribution: number;
+};
+
+export type SummaryMetricMap = {
+  uniquePlayers: number | null;
+  peakCcu: number | null;
+  minutesPerPlayer: number | null;
+  retentionD1: number | null;
+  retentionD7: number | null;
+  recommends: number | null;
+  favorites: number | null;
+};
+
+export type MetricDelta = {
+  latest: number | null;
+  previous: number | null;
+  delta: number | null;
+  deltaPct: number | null;
+  delta24h: number | null;
+  direction: TrendDirection;
+};
+
+export type RankedIslandSummary = Island & {
+  rank?: number;
   hypeScore: number;
-  uniquePlayers: number;
-  peakCCU: number;
-  minutesPerPlayer: number;
-  retentionD1: number;
-  retentionD7?: number;
-  recommends?: number;
-  favorites?: number;
+  updatedAt?: string;
+  metrics: SummaryMetricMap;
+  deltas: Partial<Record<IslandMetricName, MetricDelta>> & {
+    latestChange?: number | null;
+  };
+  breakdown: HypeScoreComponent[];
 };
 
-export type IslandMetricSerie = {
-  metric: string;
+export type RankedIsland = RankedIslandSummary;
+
+export type DashboardFacet = {
+  value: string;
+  count: number;
+};
+
+export type DashboardResponse = {
+  window: TimeWindow;
+  ranking: RankedIslandSummary[];
+  rising: RankedIslandSummary[];
+  highRetention: RankedIslandSummary[];
+  highRecommend: RankedIslandSummary[];
+  facets: {
+    tags: DashboardFacet[];
+    creators: DashboardFacet[];
+  };
+  updatedAt: string;
+  degraded: boolean;
+  partialFailures: string[];
+};
+
+export type IslandOverviewResponse = {
+  window: TimeWindow;
+  island: Island;
+  kpis: SummaryMetricMap;
+  deltas: Partial<Record<IslandMetricName, MetricDelta>> & {
+    latestChange?: number | null;
+  };
+  hypeScore: {
+    score: number;
+    breakdown: HypeScoreComponent[];
+  };
+  related: RankedIslandSummary[];
+  series: MetricSeries[];
+  researchStatus: {
+    available: boolean;
+    updatedAt?: string | null;
+  };
+  updatedAt: string;
+  degraded: boolean;
+};
+
+export type CompareMetricScore = {
+  raw: number | null;
+  normalized: number | null;
+};
+
+export type CompareIslandResult = {
+  island: RankedIslandSummary;
+  series: MetricSeries[];
+  normalizedScores: Partial<Record<IslandMetricName, CompareMetricScore>>;
+};
+
+export type CompareResponse = {
+  window: TimeWindow;
+  islands: CompareIslandResult[];
+  updatedAt: string;
+  degraded: boolean;
+};
+
+export type ResearchSource = {
+  title?: string;
+  url: string;
+};
+
+export type Research = {
+  summary: string;
+  highlights?: string[];
+  sources?: ResearchSource[];
+  updatedAt: string;
+};
+
+export type IslandsSearchParams = {
+  window: TimeWindow;
+  query?: string;
+  category?: string;
+  limit?: number;
+  sort?: string;
+};
+
+export type DashboardRequest = {
+  window: TimeWindow;
+  sort?: DashboardSort;
+  tags?: string[];
+  creator?: string;
+};
+
+export type IslandOverviewRequest = {
+  code: string;
+  window: TimeWindow;
+};
+
+export type CompareRequest = {
+  codes: string[];
+  window: TimeWindow;
+};
+
+export type HomeQueryState = {
+  window: TimeWindow;
+  tab: DashboardTab;
+  sort: DashboardSort;
+  query: string;
+  tags: string[];
+  creator: string;
+  view: DashboardView;
+};
+
+export type DetailQueryState = {
+  window: TimeWindow;
+};
+
+export type CompareQueryState = {
+  window: TimeWindow;
+  codes: string[];
+};
+
+export type CompareDraft = {
+  codes: string[];
+  updatedAt: string;
+};
+
+export type WatchlistEntry = {
+  code: string;
   name: string;
   creator: string;
-  hypeScore: number;
+  tags?: string[];
+  savedAt: string;
 };
 
-export type MetricPoint = { ts: string; value: number };
+export type RecentSearchEntry = {
+  query: string;
+  usedAt: string;
+};
 
+export type RecentViewEntry = {
+  code: string;
+  name: string;
+  creator: string;
+  viewedAt: string;
+  window: TimeWindow;
+};
 
+export type IslandMetricSerie = MetricSeries;

--- a/web/src/lib/urlState.test.tsx
+++ b/web/src/lib/urlState.test.tsx
@@ -1,0 +1,133 @@
+import type { PropsWithChildren } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  parseCompareQueryState,
+  parseHomeQueryState,
+  serializeCompareQueryState,
+  serializeHomeQueryState,
+  toCompareRequest,
+  toDashboardRequest,
+  useCompareQueryState,
+  useHomeQueryState
+} from './urlState';
+
+function createWrapper(initialEntry: string) {
+  return function Wrapper({ children }: PropsWithChildren) {
+    return (
+      <MemoryRouter
+        initialEntries={[initialEntry]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        {children}
+      </MemoryRouter>
+    );
+  };
+}
+
+describe('urlState', () => {
+  it('parses home query state with defaults and normalized lists', () => {
+    const state = parseHomeQueryState('?window=1h&tab=rising&sort=peakCcu&query=%20zone%20&tags=pvp,co-op&tags=co-op&creator=Epic&view=cards');
+
+    expect(state).toEqual({
+      window: '1h',
+      tab: 'rising',
+      sort: 'peakCcu',
+      query: 'zone',
+      tags: ['pvp', 'co-op'],
+      creator: 'Epic',
+      view: 'cards'
+    });
+  });
+
+  it('serializes home query state without default values', () => {
+    const searchParams = serializeHomeQueryState({
+      window: '10m',
+      tab: 'top',
+      sort: 'hype',
+      query: 'battle',
+      tags: ['action', 'action', 'team'],
+      creator: '',
+      view: 'cards'
+    });
+
+    expect(searchParams.toString()).toBe('query=battle&tags=action%2Cteam&view=cards');
+  });
+
+  it('parses compare codes and caps them at 4', () => {
+    const state = parseCompareQueryState('?window=24h&codes=1111,2222,2222&codes=3333,4444,5555');
+
+    expect(state).toEqual({
+      window: '24h',
+      codes: ['1111', '2222', '3333', '4444']
+    });
+  });
+
+  it('builds dashboard and compare API requests from state', () => {
+    expect(
+      toDashboardRequest({
+        window: '24h',
+        tab: 'top',
+        sort: 'favorites',
+        query: '',
+        tags: ['co-op'],
+        creator: 'Epic',
+        view: 'table'
+      })
+    ).toEqual({
+      window: '24h',
+      sort: 'favorites',
+      tags: ['co-op'],
+      creator: 'Epic'
+    });
+
+    expect(
+      toCompareRequest({
+        window: '1h',
+        codes: ['1111', '2222']
+      })
+    ).toEqual({
+      window: '1h',
+      codes: ['1111', '2222']
+    });
+  });
+
+  it('updates home query params through the hook API', () => {
+    const { result } = renderHook(() => useHomeQueryState(), {
+      wrapper: createWrapper('/?window=1h')
+    });
+
+    act(() => {
+      result.current[1]({
+        query: 'zone wars',
+        tags: ['pvp', 'ranked'],
+        view: 'cards'
+      });
+    });
+
+    expect(result.current[0]).toEqual({
+      window: '1h',
+      tab: 'top',
+      sort: 'hype',
+      query: 'zone wars',
+      tags: ['pvp', 'ranked'],
+      creator: '',
+      view: 'cards'
+    });
+  });
+
+  it('updates compare codes through the hook API', () => {
+    const { result } = renderHook(() => useCompareQueryState(), {
+      wrapper: createWrapper('/compare?codes=1111')
+    });
+
+    act(() => {
+      result.current[1]((current) => ({
+        codes: [...current.codes, '2222', '3333', '4444', '5555']
+      }));
+    });
+
+    expect(serializeCompareQueryState(result.current[0]).toString()).toBe('codes=1111%2C2222%2C3333%2C4444');
+  });
+});

--- a/web/src/lib/urlState.ts
+++ b/web/src/lib/urlState.ts
@@ -1,0 +1,186 @@
+import { useSearchParams } from 'react-router-dom';
+import type {
+  CompareQueryState,
+  CompareRequest,
+  DashboardRequest,
+  DashboardSort,
+  DashboardTab,
+  DashboardView,
+  DetailQueryState,
+  HomeQueryState,
+  TimeWindow
+} from './types';
+
+const WINDOWS: TimeWindow[] = ['10m', '1h', '24h'];
+const TABS: DashboardTab[] = ['top', 'rising'];
+const SORTS: DashboardSort[] = [
+  'hype',
+  'uniquePlayers',
+  'peakCcu',
+  'minutesPerPlayer',
+  'retentionD1',
+  'recommends',
+  'favorites',
+  'latestChange'
+];
+const VIEWS: DashboardView[] = ['table', 'cards'];
+
+export const DEFAULT_HOME_QUERY_STATE: HomeQueryState = {
+  window: '10m',
+  tab: 'top',
+  sort: 'hype',
+  query: '',
+  tags: [],
+  creator: '',
+  view: 'table'
+};
+
+export const DEFAULT_DETAIL_QUERY_STATE: DetailQueryState = {
+  window: '10m'
+};
+
+export const DEFAULT_COMPARE_QUERY_STATE: CompareQueryState = {
+  window: '10m',
+  codes: []
+};
+
+type SearchPatch<T> = Partial<T> | ((current: T) => Partial<T>);
+
+function normalizeList(values: string[], maxItems?: number): string[] {
+  const deduped = [...new Set(values.flatMap((value) => value.split(',')).map((value) => value.trim()).filter(Boolean))];
+  return maxItems ? deduped.slice(0, maxItems) : deduped;
+}
+
+function pickOne<T extends string>(value: string | null, allowed: readonly T[], fallback: T): T {
+  return value && allowed.includes(value as T) ? (value as T) : fallback;
+}
+
+function parseWindow(searchParams: URLSearchParams): TimeWindow {
+  return pickOne(searchParams.get('window'), WINDOWS, DEFAULT_HOME_QUERY_STATE.window);
+}
+
+export function parseHomeQueryState(input: URLSearchParams | string): HomeQueryState {
+  const searchParams = typeof input === 'string' ? new URLSearchParams(input) : input;
+
+  return {
+    window: parseWindow(searchParams),
+    tab: pickOne(searchParams.get('tab'), TABS, DEFAULT_HOME_QUERY_STATE.tab),
+    sort: pickOne(searchParams.get('sort'), SORTS, DEFAULT_HOME_QUERY_STATE.sort),
+    query: (searchParams.get('query') ?? '').trim(),
+    tags: normalizeList(searchParams.getAll('tags').concat(searchParams.get('tags') ?? '')),
+    creator: (searchParams.get('creator') ?? '').trim(),
+    view: pickOne(searchParams.get('view'), VIEWS, DEFAULT_HOME_QUERY_STATE.view)
+  };
+}
+
+export function parseDetailQueryState(input: URLSearchParams | string): DetailQueryState {
+  const searchParams = typeof input === 'string' ? new URLSearchParams(input) : input;
+  return {
+    window: parseWindow(searchParams)
+  };
+}
+
+export function parseCompareQueryState(input: URLSearchParams | string): CompareQueryState {
+  const searchParams = typeof input === 'string' ? new URLSearchParams(input) : input;
+  return {
+    window: parseWindow(searchParams),
+    codes: normalizeList(searchParams.getAll('codes').concat(searchParams.get('codes') ?? ''), 4)
+  };
+}
+
+export function serializeHomeQueryState(state: Partial<HomeQueryState>): URLSearchParams {
+  const nextState = { ...DEFAULT_HOME_QUERY_STATE, ...state };
+  const searchParams = new URLSearchParams();
+
+  if (nextState.window !== DEFAULT_HOME_QUERY_STATE.window) {
+    searchParams.set('window', nextState.window);
+  }
+  if (nextState.tab !== DEFAULT_HOME_QUERY_STATE.tab) {
+    searchParams.set('tab', nextState.tab);
+  }
+  if (nextState.sort !== DEFAULT_HOME_QUERY_STATE.sort) {
+    searchParams.set('sort', nextState.sort);
+  }
+  if (nextState.query.trim()) {
+    searchParams.set('query', nextState.query.trim());
+  }
+  if (nextState.tags.length > 0) {
+    searchParams.set('tags', normalizeList(nextState.tags).join(','));
+  }
+  if (nextState.creator.trim()) {
+    searchParams.set('creator', nextState.creator.trim());
+  }
+  if (nextState.view !== DEFAULT_HOME_QUERY_STATE.view) {
+    searchParams.set('view', nextState.view);
+  }
+
+  return searchParams;
+}
+
+export function serializeDetailQueryState(state: Partial<DetailQueryState>): URLSearchParams {
+  const nextState = { ...DEFAULT_DETAIL_QUERY_STATE, ...state };
+  const searchParams = new URLSearchParams();
+  if (nextState.window !== DEFAULT_DETAIL_QUERY_STATE.window) {
+    searchParams.set('window', nextState.window);
+  }
+  return searchParams;
+}
+
+export function serializeCompareQueryState(state: Partial<CompareQueryState>): URLSearchParams {
+  const nextState = { ...DEFAULT_COMPARE_QUERY_STATE, ...state };
+  const searchParams = new URLSearchParams();
+
+  if (nextState.window !== DEFAULT_COMPARE_QUERY_STATE.window) {
+    searchParams.set('window', nextState.window);
+  }
+  if (nextState.codes.length > 0) {
+    searchParams.set('codes', normalizeList(nextState.codes, 4).join(','));
+  }
+
+  return searchParams;
+}
+
+export function toDashboardRequest(state: HomeQueryState): DashboardRequest {
+  return {
+    window: state.window,
+    sort: state.sort,
+    tags: state.tags,
+    creator: state.creator || undefined
+  };
+}
+
+export function toCompareRequest(state: CompareQueryState): CompareRequest {
+  return {
+    window: state.window,
+    codes: state.codes
+  };
+}
+
+function useSearchState<T>(
+  parser: (searchParams: URLSearchParams) => T,
+  serializer: (state: Partial<T>) => URLSearchParams,
+  defaults: T
+) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const state = parser(searchParams);
+
+  const updateState = (patch: SearchPatch<T>, options?: { replace?: boolean }) => {
+    const partial = typeof patch === 'function' ? patch(state) : patch;
+    const nextState = { ...defaults, ...state, ...partial };
+    setSearchParams(serializer(nextState), { replace: options?.replace ?? true });
+  };
+
+  return [state, updateState] as const;
+}
+
+export function useHomeQueryState() {
+  return useSearchState(parseHomeQueryState, serializeHomeQueryState, DEFAULT_HOME_QUERY_STATE);
+}
+
+export function useDetailWindowState() {
+  return useSearchState(parseDetailQueryState, serializeDetailQueryState, DEFAULT_DETAIL_QUERY_STATE);
+}
+
+export function useCompareQueryState() {
+  return useSearchState(parseCompareQueryState, serializeCompareQueryState, DEFAULT_COMPARE_QUERY_STATE);
+}

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,0 +1,33 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+function createMemoryStorage() {
+  const store = new Map<string, string>();
+
+  return {
+    getItem(key: string) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    clear() {
+      store.clear();
+    }
+  };
+}
+
+Object.defineProperty(window, 'localStorage', {
+  configurable: true,
+  writable: true,
+  value: createMemoryStorage()
+});
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.ts'
+  }
+});


### PR DESCRIPTION
## Summary
- add URL state helpers and storage primitives for dashboard v2
- establish frontend shell/components foundation for the v2 dashboard work
- prepare the web app for dashboard/detail/compare/watchlist flows

## Notes
- this branch is a frontend foundation worktree and is superseded by the integrated implementation in #6
- opened as draft to preserve the worktree branch without implying it is the preferred merge target

## Testing
- not re-run in this branch during PR creation flow