### PR TITLE
feat(functions): add v2 backend foundation

### DIFF
--- a/functions/src/index.test.ts
+++ b/functions/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildPerplexityPrompts } from './index.js';
+import { buildPerplexityPrompts } from './lib/research.js';
 
 describe('buildPerplexityPrompts', () => {
   it('ja prompt contains required headings and prefers sources', () => {
@@ -26,5 +26,4 @@ describe('buildPerplexityPrompts', () => {
     expect(user).toMatch(/YouTube|Reddit|official/);
   });
 });
-
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,544 +1,169 @@
-import express from 'express';
 import cors from 'cors';
+import express from 'express';
 import { onRequest } from 'firebase-functions/v2/https';
 import { onSchedule } from 'firebase-functions/v2/scheduler';
-import fetch from 'node-fetch';
-import { globalCache } from './cache.js';
+import { getIslandMetrics, getTopIslandBasics, searchIslands } from './lib/fortnite.js';
+import { buildPerplexityPrompts, fetchResearch } from './lib/research.js';
+import { getCompare, getDashboard, getIslandOverview, getWindowSummaries } from './lib/service.js';
+import type { SummarySortKey, TimeWindow } from './lib/types.js';
 
 const app = express();
 app.use(cors());
 
-const USE_MOCK = process.env.USE_MOCK === '1';
-const FORTNITE_API_BASE = 'https://api.fortnite.com';
-
-type Bucket = 'TEN_MINUTE' | 'HOUR' | 'DAY';
-
-function toBucket(window: string): Bucket {
-  if (window === '10m') return 'TEN_MINUTE';
-  if (window === '1h') return 'HOUR';
-  return 'DAY';
+function parseWindow(value: unknown): TimeWindow {
+  if (value === '1h' || value === '24h') {
+    return value;
+  }
+  return '10m';
 }
 
-function toBucketSlug(bucket: Bucket): 'ten-minute' | 'hour' | 'day' {
-  if (bucket === 'TEN_MINUTE') return 'ten-minute';
-  if (bucket === 'HOUR') return 'hour';
-  return 'day';
+function parseSort(value: unknown): SummarySortKey {
+  if (
+    value === 'uniquePlayers' ||
+    value === 'peakCcu' ||
+    value === 'minutesPerPlayer' ||
+    value === 'retentionD1' ||
+    value === 'recommends' ||
+    value === 'favorites' ||
+    value === 'latestChange'
+  ) {
+    return value;
+  }
+  return 'hype';
 }
 
-function toMetricSlug(metric: string): string {
-  const map: Record<string, string> = {
-    uniquePlayers: 'unique-players',
-    peakCcu: 'peak-ccu',
-    minutesPerPlayer: 'minutes-per-player',
-    retentionD1: 'retention-d1',
-    retentionD7: 'retention-d7',
-    recommends: 'recommends',
-    favorites: 'favorites',
-    plays: 'plays',
-    minutesPlayed: 'minutes-played'
-  };
-  return map[metric] || metric.replace(/[A-Z]/g, m => `-${m.toLowerCase()}`);
+function parseTags(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap(entry => String(entry).split(',')).map(entry => entry.trim()).filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value.split(',').map(entry => entry.trim()).filter(Boolean);
+  }
+  return [];
 }
 
-async function runLimited<T>(inputs: T[], limit: number, worker: (input: T) => Promise<void>): Promise<void> {
-  const size = Math.max(1, Math.min(limit, inputs.length));
-  let cursor = 0;
-  const workers = Array.from({ length: size }, async () => {
-    while (true) {
-      const index = cursor++;
-      if (index >= inputs.length) break;
-      await worker(inputs[index]);
-    }
-  });
-  await Promise.all(workers);
+function parseCodes(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap(entry => String(entry).split(',')).map(entry => entry.trim()).filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value.split(',').map(entry => entry.trim()).filter(Boolean);
+  }
+  return [];
 }
 
-function ttlForWindow(window: string) {
-  if (window === '10m') return 600;
-  if (window === '1h') return 900;
-  return 900;
+function sendCachedJson(res: express.Response, payload: unknown, maxAge = 300, sMaxAge = 600) {
+  res.set('Cache-Control', `public, max-age=${maxAge}, s-maxage=${sMaxAge}`);
+  res.json(payload);
 }
 
-app.get(['/health', '/api/health'], (_req, res) => res.json({ ok: true }));
+app.get(['/health', '/api/health'], (_req, res) => {
+  res.json({ ok: true });
+});
 
 app.get(['/islands', '/api/islands'], async (req, res) => {
-  const window = (req.query.window as string) || '10m';
-  const query = (req.query.query as string) || '';
-  const sort = (req.query.sort as string) || 'hype';
-  const limit = Number(req.query.limit || 50);
-  const cacheKey = `islands:v5:${window}:${query}:${sort}:${limit}`;
-
-  const cached = globalCache.get<any[]>(cacheKey);
-  if (cached) {
-    res.set('Cache-Control', 'public, max-age=300, s-maxage=600');
-    return res.json(cached);
-  }
-
-  if (USE_MOCK) {
-    const data = await import('../mocks/islands.json', { assert: { type: 'json' } });
-    const items = (data.default || (data as any)).items as any[];
-    const filtered = query ? items.filter(i => i.name.toLowerCase().includes(query.toLowerCase()) || i.code.includes(query)) : items;
-    const limited = filtered.slice(0, limit);
-    globalCache.set(cacheKey, limited, ttlForWindow(window));
-    res.set('Cache-Control', 'public, max-age=300, s-maxage=600');
-    return res.json(limited);
-  }
-
   try {
-    const listUrl = new URL('https://api.fortnite.com/ecosystem/v1/islands');
-    const q = (query || '').trim();
-    // 短すぎる検索語はAPIに投げず、通常リストを表示
-    if (q.length >= 2) listUrl.searchParams.set('search', q);
-    listUrl.searchParams.set('limit', String(limit));
+    const window = parseWindow(req.query.window);
+    const query = typeof req.query.query === 'string' ? req.query.query : '';
+    const sort = typeof req.query.sort === 'string' ? req.query.sort : 'hype';
+    const limit = Math.min(Number(req.query.limit || 50), 100);
+    const islands = await searchIslands({ window, query, sort, limit });
+    sendCachedJson(res, islands);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
 
-    const listRes = await fetch(listUrl.toString());
-    // 上流エラーの一部は空配列でフォールバック（UIで500にしない）
-    if (!listRes.ok) {
-      if ([400, 404, 422, 429].includes(listRes.status)) {
-        globalCache.set(cacheKey, [], ttlForWindow(window));
-        res.set('Cache-Control', 'public, max-age=60, s-maxage=120');
-        return res.json([]);
-      }
-      throw new Error(`Upstream island list failed with ${listRes.status}`);
-    }
-    const listJson = (await listRes.json()) as any;
-
-    let islands = (listJson.items || listJson.data || [])
-      .map((i: any) => ({
-        code: i.code,
-        name: i.title,
-        creator: i.creatorCode || i.creator?.name || i.creator || 'Unknown',
-        tags: i.tags || []
-      }))
-      .filter((i: any) => i.code && i.name);
-
-    // 人気の高いIslandを優先取得：uniquePlayersの直近値で降順ソート
-    if (islands.length > 0 && (sort === 'hype' || sort === 'popular')) {
-      const bucket = toBucket(window);
-      // パス形式のメトリクスAPIを使用（start/end は省略）
-
-      const uniqueMap = new Map<string, number>();
-
-      const runFetch = async (islandCode: string) => {
-        try {
-          const bucketSlug = toBucketSlug(bucket);
-          const metricSlug = toMetricSlug('uniquePlayers');
-          const url = new URL(`/ecosystem/v1/islands/${encodeURIComponent(islandCode)}/metrics/${bucketSlug}/${metricSlug}`, FORTNITE_API_BASE);
-          const r = await fetch(url.toString());
-          if (r.ok) {
-            const j = (await r.json()) as any;
-            const pointsRaw = j.series || j.data || j.points || j.intervals || [];
-            const last = Array.isArray(pointsRaw) && pointsRaw.length > 0
-              ? pointsRaw[pointsRaw.length - 1]
-              : null;
-            const value = last
-              ? (last.value ?? last.v ?? (Array.isArray(last) ? last[1] : 0))
-              : 0;
-            uniqueMap.set(islandCode, Number(value) || 0);
-          } else {
-            uniqueMap.set(islandCode, 0);
-          }
-        } catch {
-          uniqueMap.set(islandCode, 0);
-        }
-      };
-
-      await runLimited(islands, 8, async (it) => runFetch((it as any).code));
-
-      islands.sort((a: any, b: any) => (uniqueMap.get(b.code) || 0) - (uniqueMap.get(a.code) || 0));
-
-      // 上位の島の詳細メトリクスを事前取得してキャッシュ（最大5件・並列3）
-      const prefetchTargets = islands.slice(0, Math.min(5, islands.length));
-      const metricsList = [
-        'uniquePlayers',
-        'peakCcu',
-        'minutesPerPlayer',
-        'retentionD1',
-        'retentionD7',
-        'recommends',
-        'favorites'
-      ];
-      const prefetchOne = async (code: string) => {
-        try {
-          const series = await Promise.all(
-            metricsList.map(async (metric) => {
-              const bucketSlug = toBucketSlug(bucket);
-              const metricSlug = toMetricSlug(metric);
-              const u = new URL(`/ecosystem/v1/islands/${encodeURIComponent(code)}/metrics/${bucketSlug}/${metricSlug}`, FORTNITE_API_BASE);
-              const r = await fetch(u.toString());
-              if (r.ok) {
-                const j = (await r.json()) as any;
-                const pointsRaw = j.series || j.data || j.points || j.intervals || [];
-                const points = Array.isArray(pointsRaw)
-                  ? pointsRaw.map((p: any) => ({ ts: p.timestamp || p.ts || p.time || p[0], value: p.value ?? p.v ?? p[1] }))
-                  : [];
-                return { metric, points };
-              }
-              return { metric, points: [] };
-            })
-          );
-          const cacheKeyM = `metrics:v2:${code}:${window}`;
-          globalCache.set(cacheKeyM, series, ttlForWindow(window));
-        } catch {
-          // ignore prefetch errors
-        }
-      };
-      await runLimited(prefetchTargets, 3, async (it) => prefetchOne((it as any).code));
-
-      // uniquePlayers 簡易スコアを添付（前段の動作確認・監視用）
-      islands = islands.map((it: any) => ({ ...it, metrics: { uniquePlayers: uniqueMap.get(it.code) || 0 } }));
-    }
-
-    globalCache.set(cacheKey, islands, ttlForWindow(window));
-    res.set('Cache-Control', 'public, max-age=300, s-maxage=600');
-    res.json(islands);
-  } catch (e: any) {
-    res.status(500).json({ error: e.message });
+app.get(['/dashboard', '/api/dashboard'], async (req, res) => {
+  try {
+    const window = parseWindow(req.query.window);
+    const sort = parseSort(req.query.sort);
+    const tags = parseTags(req.query.tags);
+    const creator = typeof req.query.creator === 'string' ? req.query.creator : '';
+    const dashboard = await getDashboard({ window, sort, tags, creator });
+    sendCachedJson(res, dashboard);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
   }
 });
 
 app.get(['/islands/:code/metrics', '/api/islands/:code/metrics'], async (req, res) => {
-  const code = req.params.code;
-  const window = (req.query.window as string) || '10m';
-  const cacheKey = `metrics:v2:${code}:${window}`;
-  const cached = globalCache.get<any[]>(cacheKey);
-  if (cached) {
-    res.set('Cache-Control', 'public, max-age=300, s-maxage=600');
-    return res.json(cached);
-  }
-
-  if (USE_MOCK) {
-    const all = await import('../mocks/metrics_by_code.json', { assert: { type: 'json' } }) as any;
-    const series = (all.default || all)[code] || [];
-    globalCache.set(cacheKey, series, ttlForWindow(window));
-    res.set('Cache-Control', 'public, max-age=300, s-maxage=600');
-    return res.json(series);
-  }
-
   try {
-    const bucket = toBucket(window);
-    // パス形式APIに合わせ、時間範囲はAPIサイドのデフォルトに委ねる
-    const metrics = [
-      'uniquePlayers',
-      'peakCcu',
-      'minutesPerPlayer',
-      'retentionD1',
-      'retentionD7',
-      'recommends',
-      'favorites',
-      'plays',
-      'minutesPlayed'
-    ];
+    const window = parseWindow(req.query.window);
+    const series = await getIslandMetrics(req.params.code, window);
+    sendCachedJson(res, series);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
 
-    const fetchMetric = async (metric: string) => {
-      const bucketSlug = toBucketSlug(bucket);
-      const metricSlug = toMetricSlug(metric);
-      const url = new URL(`/ecosystem/v1/islands/${encodeURIComponent(code)}/metrics/${bucketSlug}/${metricSlug}`, FORTNITE_API_BASE);
+app.get(['/islands/:code/overview', '/api/islands/:code/overview'], async (req, res) => {
+  try {
+    const window = parseWindow(req.query.window);
+    const overview = await getIslandOverview({
+      code: req.params.code,
+      window,
+      researchConfigured: Boolean(process.env.PERPLEXITY_API_KEY)
+    });
+    sendCachedJson(res, overview);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
 
-      const r = await fetch(url.toString());
-      if (r.ok) {
-        const j = (await r.json()) as any;
-        const pointsRaw = j.series || j.data || j.points || j.intervals || [];
-        const points = Array.isArray(pointsRaw)
-          ? pointsRaw.map((p: any) => ({ ts: p.timestamp || p.ts || p.time || p[0], value: p.value ?? p.v ?? p[1] }))
-          : [];
-        return { metric, points };
-      }
-      return { metric, points: [] };
-    };
+app.get(['/compare', '/api/compare'], async (req, res) => {
+  try {
+    const window = parseWindow(req.query.window);
+    const codes = parseCodes(req.query.codes);
+    if (codes.length < 2) {
+      return res.status(400).json({ error: 'At least 2 island codes are required' });
+    }
 
-    const series = await Promise.all(metrics.map(fetchMetric));
-    globalCache.set(cacheKey, series, ttlForWindow(window));
-    res.set('Cache-Control', 'public, max-age=300, s-maxage=600');
-    res.json(series);
-  } catch (e: any) {
-    res.status(500).json({ error: e.message });
+    const compare = await getCompare({ codes, window });
+    sendCachedJson(res, compare);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+app.get(['/top-islands', '/api/top-islands'], async (req, res) => {
+  try {
+    const window = parseWindow(req.query.window);
+    const limit = Math.min(Number(req.query.limit || 100), 500);
+    const query = typeof req.query.query === 'string' ? req.query.query : '';
+    const islands = await getTopIslandBasics(window, limit, query);
+    sendCachedJson(res, islands);
+  } catch (error: any) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+app.get(['/islands/:code/research', '/api/islands/:code/research'], async (req, res) => {
+  try {
+    const data = await fetchResearch({
+      code: req.params.code,
+      name: typeof req.query.name === 'string' ? req.query.name : '',
+      lang: typeof req.query.lang === 'string' ? req.query.lang : 'ja'
+    });
+    sendCachedJson(res, data);
+  } catch (error: any) {
+    const message = error.message || String(error);
+    const status = message.includes('PERPLEXITY_API_KEY') ? 501 : 500;
+    res.status(status).json({ error: message });
   }
 });
 
 export const api = onRequest({ region: 'us-central1' }, app);
 
-// ----------------------
-// Top islands (full crawl)
-// ----------------------
-
-type IslandBasic = { code: string; name: string; creator: string; tags?: string[] };
-
-async function fetchIslandsPage(url: URL): Promise<{ items: any[]; nextUrl: URL | null }> {
-  const res = await fetch(url.toString());
-  if (!res.ok) throw new Error(`Upstream islands page failed: ${res.status}`);
-  const j = (await res.json()) as any;
-  const items = (j.items || j.data || []) as any[];
-  let nextUrl: URL | null = null;
-  const next = j.next || j.nextUrl || j.links?.next;
-  if (typeof next === 'string') {
-    try { nextUrl = new URL(next, FORTNITE_API_BASE); } catch { nextUrl = null; }
-  }
-  return { items, nextUrl };
-}
-
-async function crawlAllIslands(maxPages: number, pageSize: number, search: string | undefined): Promise<IslandBasic[]> {
-  // 初回URL
-  const first = new URL('/ecosystem/v1/islands', FORTNITE_API_BASE);
-  first.searchParams.set('limit', String(pageSize));
-  if (search) first.searchParams.set('search', search);
-  let url: URL | null = first;
-  const out: IslandBasic[] = [];
-  let page = 0;
-  while (url && page < maxPages) {
-    // フォールバックとして page/pageNumber も試す
-    url.searchParams.set('page', String(page + 1));
-    const { items, nextUrl } = await fetchIslandsPage(url);
-    for (const i of items) {
-      const it: IslandBasic = {
-        code: i.code,
-        name: i.title,
-        creator: i.creatorCode || i.creator?.name || i.creator || 'Unknown',
-        tags: i.tags || []
-      };
-      if (it.code && it.name) out.push(it);
-    }
-    page++;
-    if (nextUrl) {
-      url = nextUrl;
-    } else {
-      if (items.length < pageSize) break; // 末尾
-      // 次ページを推測
-      const guess = new URL('/ecosystem/v1/islands', FORTNITE_API_BASE);
-      guess.searchParams.set('limit', String(pageSize));
-      guess.searchParams.set('page', String(page + 1));
-      if (search) guess.searchParams.set('search', search);
-      url = guess;
-    }
-  }
-  return out;
-}
-
-async function computePopularIslands(window: string, limit: number, search?: string): Promise<IslandBasic[]> {
-  const bucket = toBucket(window);
-  // パス形式APIの既定の時間範囲を利用
-
-  const all = await crawlAllIslands(20, 100, search); // 最大 ~2000 件想定（API制限に注意）
-
-  const uniqueMap = new Map<string, number>();
-  await runLimited(all, 10, async (it) => {
-    try {
-      const bucketSlug = toBucketSlug(bucket);
-      const metricSlug = toMetricSlug('uniquePlayers');
-      const u = new URL(`/ecosystem/v1/islands/${encodeURIComponent(it.code)}/metrics/${bucketSlug}/${metricSlug}`, FORTNITE_API_BASE);
-      const r = await fetch(u.toString());
-      if (r.ok) {
-        const j = (await r.json()) as any;
-        const pointsRaw = j.series || j.data || j.points || j.intervals || [];
-        const last = Array.isArray(pointsRaw) && pointsRaw.length > 0 ? pointsRaw[pointsRaw.length - 1] : null;
-        const value = last ? (last.value ?? last.v ?? (Array.isArray(last) ? last[1] : 0)) : 0;
-        uniqueMap.set(it.code, Number(value) || 0);
-      } else {
-        uniqueMap.set(it.code, 0);
-      }
-    } catch {
-      uniqueMap.set(it.code, 0);
-    }
-  });
-
-  const sorted = [...all].sort((a, b) => (uniqueMap.get(b.code) || 0) - (uniqueMap.get(a.code) || 0));
-  return sorted.slice(0, Math.min(limit, sorted.length));
-}
-
-app.get(['/top-islands', '/api/top-islands'], async (req, res) => {
-  const window = (req.query.window as string) || '10m';
-  const limit = Math.min(Number(req.query.limit || 100), 500);
-  const query = (req.query.query as string) || '';
-  const cacheKey = `top:v1:${window}:${limit}:${query}`;
-  const cached = globalCache.get<IslandBasic[]>(cacheKey);
-  if (cached) {
-    res.set('Cache-Control', 'public, max-age=300, s-maxage=600');
-    return res.json(cached);
-  }
-  try {
-    const top = await computePopularIslands(window, limit, query || undefined);
-    globalCache.set(cacheKey, top, ttlForWindow(window));
-    res.set('Cache-Control', 'public, max-age=300, s-maxage=600');
-    res.json(top);
-  } catch (e: any) {
-    res.status(500).json({ error: e.message });
-  }
-});
-
 export const warmTopIslands = onSchedule({ region: 'us-central1', schedule: 'every 10 minutes' }, async () => {
-  const windows = ['10m', '1h', '24h'];
-  for (const w of windows) {
+  const windows: TimeWindow[] = ['10m', '1h', '24h'];
+  for (const window of windows) {
     try {
-      const top = await computePopularIslands(w, 100);
-      const cacheKey = `top:v1:${w}:100:`;
-      globalCache.set(cacheKey, top, ttlForWindow(w));
+      await Promise.all([getTopIslandBasics(window, 100), getWindowSummaries(window)]);
     } catch {
-      // ignore
+      // Keep scheduler best-effort only.
     }
   }
 });
 
-
-// ---------------------------------
-// Research endpoint (Perplexity API)
-// ---------------------------------
-export function buildPerplexityPrompts(lang: string, titlePart: string) {
-  const system =
-    lang === 'ja'
-      ? 'あなたはFortniteの島について短く要点をまとめるリサーチアシスタントです。出力は厳密にMarkdownの見出しと箇条書きを守り、事実に基づき、必ずURL付きの出典を提示してください。YouTube、Reddit、Epic/公式ドキュメントを優先し、信頼性の低いソースは避けてください。'
-      : 'You are a concise research assistant for Fortnite islands. Output must strictly follow the requested Markdown sections with bullet points, be factual, and include URL-cited sources. Prefer YouTube, Reddit, and Epic/official documentation; avoid low-quality sources.';
-
-  const user =
-    lang === 'ja'
-      ? `次の島についてリサーチし、以下のMarkdownフォーマット（見出し名は必ずこの通り）で短く要約してください。島名とコード: ${titlePart}
-
-## Island Status
-### 状況
-- （現在の状況・コミュニティでの注目点を簡潔に）
-### 概要
-- （島のタイプ/目的/プレイ要素など）
-### 特徴
-- （主要な特徴・差別化要因）
-### 話題
-- （最近の話題・アップデート・SNS/コミュニティ動向）
-
-## 出典
-- （URL）
-- （URL）
-
-厳守事項:
-- 上記の見出し・順序・箇条書きを厳密に維持。
-- 誤検出を避けるため、島コードと一致しない情報は除外。
-- 出典はYouTube、Reddit、Epic/公式ドキュメントを優先。該当がない場合のみその他の信頼できるサイトを使用。`
-      : `Research the island: ${titlePart}
-
-Strictly output the following Markdown (use these exact headings):
-
-## Island Status
-### Status
-- (current traction/community buzz, concise)
-### Overview
-- (type/purpose/core gameplay)
-### Features
-- (key differentiators)
-### Discussion
-- (recent updates/community threads/social mentions)
-
-## Sources
-- (URL)
-- (URL)
-
-Requirements:
-- Keep the exact headings/order/bullets.
-- Exclude mismatching info (must match the island code).
-- Prefer sources from YouTube, Reddit, and Epic/official docs; use other reputable sites only if necessary.`;
-
-  return { system, user };
-}
-
-app.get(['/islands/:code/research', '/api/islands/:code/research'], async (req, res) => {
-  const apiKey = process.env.PERPLEXITY_API_KEY;
-  if (!apiKey) return res.status(501).json({ error: 'PERPLEXITY_API_KEY not configured' });
-
-  const code = req.params.code;
-  const name = (req.query.name as string) || '';
-  const lang = (req.query.lang as string) || 'ja';
-  const cacheKey = `research:v1:${code}:${lang}:${name || ''}`;
-  const cached = globalCache.get<any>(cacheKey);
-  if (cached) {
-    res.set('Cache-Control', 'public, max-age=300, s-maxage=600');
-    return res.json(cached);
-  }
-
-  try {
-    const titlePart = name ? `${name} (${code})` : code;
-    const { system, user } = buildPerplexityPrompts(lang, titlePart);
-    const preferred = (process.env.PERPLEXITY_MODEL || '').trim();
-    const candidates = [
-      preferred,
-      // Online検索付き（プランにより利用可否あり）
-      'pplx-70b-online',
-      'pplx-7b-online',
-      'sonar-large-online',
-      'sonar-medium-online',
-      'sonar-small-online',
-      // Chat専用（オンライン無し）
-      'pplx-70b',
-      'pplx-7b',
-      'sonar-large-chat',
-      'sonar-medium-chat',
-      'sonar-small-chat'
-    ].filter(Boolean);
-
-    let content = '';
-    let lastErr: string | null = null;
-    for (const model of candidates) {
-      const body = {
-        model,
-        messages: [
-          { role: 'system', content: system },
-          { role: 'user', content: user }
-        ],
-        temperature: 0.2,
-        top_p: 0.9
-      } as any;
-
-      const resp = await fetch('https://api.perplexity.ai/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${apiKey}`
-        },
-        body: JSON.stringify(body)
-      });
-
-      let respJson: any = null;
-      try { respJson = await resp.json(); } catch { respJson = null; }
-      if (!resp.ok) {
-        const errType = respJson?.error?.type || '';
-        const errMsg = respJson?.error?.message || `HTTP ${resp.status}`;
-        lastErr = `${model}: ${errType || 'error'}: ${errMsg}`;
-        if (errType === 'invalid_model') {
-          continue; // try next candidate
-        }
-        // other errors: break
-        break;
-      }
-      content = respJson?.choices?.[0]?.message?.content || '';
-      if (content) {
-        lastErr = null;
-        break;
-      }
-      lastErr = `${model}: empty content`;
-    }
-    if (!content) {
-      throw new Error(`Perplexity API failed (model resolution): ${lastErr || 'unknown error'}`);
-    }
-
-    // 粗い抽出：ハイライトとURL
-    const lines = String(content).split(/\r?\n/);
-    const highlights: string[] = [];
-    const sources: { title?: string; url: string }[] = [];
-    for (const ln of lines) {
-      const t = ln.trim();
-      if (!t) continue;
-      if (/^[-•・]/.test(t)) highlights.push(t.replace(/^[-•・]\s?/, ''));
-      const m = t.match(/https?:\/\/\S+/g);
-      if (m) m.forEach(u => sources.push({ url: u }));
-    }
-
-    const result = {
-      summary: content,
-      highlights,
-      sources,
-      updatedAt: new Date().toISOString()
-    };
-
-    globalCache.set(cacheKey, result, 600);
-    res.set('Cache-Control', 'public, max-age=300, s-maxage=600');
-    res.json(result);
-  } catch (e: any) {
-    res.status(500).json({ error: e.message });
-  }
-});
-
+export { buildPerplexityPrompts };

--- a/functions/src/lib/compare.ts
+++ b/functions/src/lib/compare.ts
@@ -1,0 +1,28 @@
+import { METRIC_NAMES, type CompareResponse, type IslandSummary, type TimeWindow } from './types.js';
+import { toRanked } from './summary.js';
+
+export function buildCompareResponse(params: {
+  items: IslandSummary[];
+  window: TimeWindow;
+}): CompareResponse {
+  const items = params.items.slice(0, 4);
+
+  return {
+    window: params.window,
+    codes: items.map(item => item.code),
+    islands: items.map(toRanked),
+    metrics: METRIC_NAMES.map(metric => ({
+      metric,
+      series: items.map(item => ({
+        code: item.code,
+        name: item.name,
+        points: item.metrics[metric].points
+      }))
+    })),
+    updatedAt: (() => {
+      const updatedAt = items.map(item => item.updatedAt).sort();
+      return updatedAt[updatedAt.length - 1] ?? new Date().toISOString();
+    })(),
+    degraded: items.some(item => item.partial)
+  };
+}

--- a/functions/src/lib/dashboard.test.ts
+++ b/functions/src/lib/dashboard.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { buildDashboardResponse } from './dashboard.js';
+import { applyHypeScores, buildIslandSummary } from './summary.js';
+import type { IslandBasic, MetricSeries } from './types.js';
+
+function buildSummary(basic: IslandBasic, series: MetricSeries[]) {
+  return buildIslandSummary(basic, series);
+}
+
+describe('buildDashboardResponse', () => {
+  it('keeps section arrays intact on partial data and marks degraded', () => {
+    const summaries = applyHypeScores([
+      buildSummary(
+        {
+          code: '1111-1111-1111',
+          name: 'Alpha',
+          creator: 'Studio A',
+          tags: ['Action']
+        },
+        [
+          {
+            metric: 'uniquePlayers',
+            points: [
+              { ts: '2025-08-11T10:00:00Z', value: 100 },
+              { ts: '2025-08-11T10:10:00Z', value: 140 }
+            ]
+          }
+        ]
+      ),
+      buildSummary(
+        {
+          code: '2222-2222-2222',
+          name: 'Bravo',
+          creator: 'Studio B',
+          tags: ['Action', 'Co-op']
+        },
+        [
+          {
+            metric: 'uniquePlayers',
+            points: [
+              { ts: '2025-08-11T10:00:00Z', value: 80 },
+              { ts: '2025-08-11T10:10:00Z', value: 100 }
+            ]
+          },
+          {
+            metric: 'retentionD1',
+            points: [
+              { ts: '2025-08-11T10:00:00Z', value: 0.25 },
+              { ts: '2025-08-11T10:10:00Z', value: 0.33 }
+            ]
+          },
+          {
+            metric: 'recommends',
+            points: [
+              { ts: '2025-08-11T10:00:00Z', value: 10 },
+              { ts: '2025-08-11T10:10:00Z', value: 18 }
+            ]
+          },
+          {
+            metric: 'favorites',
+            points: [
+              { ts: '2025-08-11T10:00:00Z', value: 20 },
+              { ts: '2025-08-11T10:10:00Z', value: 24 }
+            ]
+          }
+        ]
+      )
+    ]);
+
+    const response = buildDashboardResponse({
+      summaries,
+      window: '10m',
+      sort: 'hype'
+    });
+
+    expect(response.degraded).toBe(true);
+    expect(response.ranking).toHaveLength(2);
+    expect(response.rising).toHaveLength(2);
+    expect(response.highRetention).toHaveLength(2);
+    expect(response.highRecommend).toHaveLength(2);
+    expect(response.facets.tags).toContain('Action');
+  });
+});

--- a/functions/src/lib/dashboard.ts
+++ b/functions/src/lib/dashboard.ts
@@ -1,0 +1,30 @@
+import { filterSummaries, pickTopRanked, recommendRanked, retentionRanked, risingRanked } from './summary.js';
+import type { DashboardResponse, IslandSummary, SummarySortKey, TimeWindow } from './types.js';
+
+export function buildDashboardResponse(params: {
+  summaries: IslandSummary[];
+  window: TimeWindow;
+  sort: SummarySortKey;
+  tags?: string[];
+  creator?: string;
+}): DashboardResponse {
+  const tags = params.tags ?? [];
+  const creator = params.creator ?? '';
+  const filtered = filterSummaries(params.summaries, tags, creator);
+  const updatedAtCandidates = filtered.map(summary => summary.updatedAt).sort();
+  const updatedAt = updatedAtCandidates[updatedAtCandidates.length - 1] ?? new Date().toISOString();
+
+  return {
+    window: params.window,
+    ranking: pickTopRanked(filtered, params.sort, 20),
+    rising: risingRanked(filtered, 20),
+    highRetention: retentionRanked(filtered, 6),
+    highRecommend: recommendRanked(filtered, 6),
+    facets: {
+      tags: [...new Set(params.summaries.flatMap(summary => summary.tags))].sort((left, right) => left.localeCompare(right)),
+      creators: [...new Set(params.summaries.map(summary => summary.creator))].sort((left, right) => left.localeCompare(right))
+    },
+    updatedAt,
+    degraded: filtered.some(summary => summary.partial)
+  };
+}

--- a/functions/src/lib/fortnite.ts
+++ b/functions/src/lib/fortnite.ts
@@ -1,0 +1,350 @@
+import { readFile } from 'node:fs/promises';
+import fetch from 'node-fetch';
+import { globalCache } from '../cache.js';
+import { normalizeMetricName, normalizeSeries } from './metrics.js';
+import { METRIC_NAMES, type IslandBasic, type MetricName, type MetricSeries, type TimeWindow } from './types.js';
+import { toBucket, toBucketSlug, toMetricSlug, ttlForWindow, windowStepMs } from './windows.js';
+
+const USE_MOCK = process.env.USE_MOCK === '1';
+const FORTNITE_API_BASE = 'https://api.fortnite.com';
+
+type MockIsland = IslandBasic & {
+  metrics?: Record<string, number>;
+};
+
+async function runLimited<T, R>(inputs: T[], limit: number, worker: (input: T) => Promise<R>): Promise<R[]> {
+  const size = Math.max(1, Math.min(limit, inputs.length));
+  const results = new Array<R>(inputs.length);
+  let cursor = 0;
+
+  const workers = Array.from({ length: size }, async () => {
+    while (true) {
+      const index = cursor++;
+      if (index >= inputs.length) {
+        return;
+      }
+
+      results[index] = await worker(inputs[index]);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
+function mapIsland(item: any): IslandBasic {
+  return {
+    code: item.code,
+    name: item.name || item.title,
+    creator: item.creator || item.creatorCode || item.creator?.name || 'Unknown',
+    tags: Array.isArray(item.tags) ? item.tags : []
+  };
+}
+
+async function loadMockIslands(): Promise<MockIsland[]> {
+  const raw = await readFile(new URL('../../mocks/islands.json', import.meta.url), 'utf8');
+  const items = (JSON.parse(raw) as any).items ?? [];
+  return items.map((item: any) => ({
+    ...mapIsland(item),
+    metrics: item.metrics ?? {}
+  }));
+}
+
+async function loadMockMetrics(): Promise<Record<string, Array<{ metric: string; points: Array<{ ts: string; value: number }> }>>> {
+  const raw = await readFile(new URL('../../mocks/metrics_by_code.json', import.meta.url), 'utf8');
+  return JSON.parse(raw) as Record<string, Array<{ metric: string; points: Array<{ ts: string; value: number }> }>>;
+}
+
+function buildSyntheticSeries(metric: MetricName, latest: number, window: TimeWindow): MetricSeries {
+  const step = windowStepMs(window);
+  const now = Date.now();
+  const multipliers = metric.startsWith('retention') ? [0.92, 0.95, 0.98, 1] : [0.78, 0.86, 0.93, 1];
+  const points = multipliers.map((multiplier, index) => ({
+    ts: new Date(now - step * (multipliers.length - 1 - index)).toISOString(),
+    value: Number((latest * multiplier).toFixed(metric.startsWith('retention') ? 4 : 2))
+  }));
+
+  return {
+    metric,
+    points
+  };
+}
+
+function getMockSnapshotMetric(island: MockIsland, metric: MetricName): number | null {
+  const snapshot = island.metrics ?? {};
+  const aliases: Record<MetricName, string[]> = {
+    uniquePlayers: ['uniquePlayers'],
+    peakCcu: ['peakCcu', 'peakCCU'],
+    minutesPerPlayer: ['minutesPerPlayer'],
+    retentionD1: ['retentionD1'],
+    retentionD7: ['retentionD7'],
+    recommends: ['recommends'],
+    favorites: ['favorites'],
+    plays: ['plays'],
+    minutesPlayed: ['minutesPlayed']
+  };
+
+  for (const key of aliases[metric]) {
+    const value = snapshot[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+export async function searchIslands(params: {
+  window: TimeWindow;
+  query?: string;
+  sort?: string;
+  limit?: number;
+}): Promise<Array<IslandBasic & { metrics?: { uniquePlayers: number | null } }>> {
+  const limit = params.limit ?? 50;
+  const query = (params.query ?? '').trim().toLowerCase();
+  const cacheKey = `islands:v6:${params.window}:${query}:${params.sort ?? 'hype'}:${limit}`;
+  const cached = globalCache.get<Array<IslandBasic & { metrics?: { uniquePlayers: number | null } }>>(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  if (USE_MOCK) {
+    const islands = await loadMockIslands();
+    const filtered = islands.filter(island => {
+      if (!query) return true;
+      return island.name.toLowerCase().includes(query) || island.code.includes(query);
+    });
+
+    const sorted = [...filtered].sort(
+      (left, right) => (getMockSnapshotMetric(right, 'uniquePlayers') ?? 0) - (getMockSnapshotMetric(left, 'uniquePlayers') ?? 0)
+    );
+    const result = sorted.slice(0, limit).map(island => ({
+      code: island.code,
+      name: island.name,
+      creator: island.creator,
+      tags: island.tags,
+      metrics: {
+        uniquePlayers: getMockSnapshotMetric(island, 'uniquePlayers')
+      }
+    }));
+    globalCache.set(cacheKey, result, ttlForWindow(params.window));
+    return result;
+  }
+
+  const listUrl = new URL('/ecosystem/v1/islands', FORTNITE_API_BASE);
+  if (query.length >= 2) {
+    listUrl.searchParams.set('search', query);
+  }
+  listUrl.searchParams.set('limit', String(limit));
+
+  const response = await fetch(listUrl.toString());
+  if (!response.ok) {
+    if ([400, 404, 422, 429].includes(response.status)) {
+      globalCache.set(cacheKey, [], 120);
+      return [];
+    }
+    throw new Error(`Upstream island list failed with ${response.status}`);
+  }
+
+  const body = (await response.json()) as any;
+  const islands = ((body.items || body.data || []) as any[]).map(mapIsland);
+  const result = islands.map(island => ({ ...island, metrics: { uniquePlayers: null } }));
+  globalCache.set(cacheKey, result, ttlForWindow(params.window));
+  return result;
+}
+
+export async function getIslandMetrics(code: string, window: TimeWindow): Promise<MetricSeries[]> {
+  const cacheKey = `metrics:v3:${code}:${window}`;
+  const cached = globalCache.get<MetricSeries[]>(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  if (USE_MOCK) {
+    const [metricMap, islands] = await Promise.all([loadMockMetrics(), loadMockIslands()]);
+    const island = islands.find(entry => entry.code === code);
+    const fromMock = (metricMap[code] ?? [])
+      .map(entry => normalizeSeries(entry.metric, entry.points))
+      .filter((entry): entry is MetricSeries => entry !== null);
+
+    const existing = new Set(fromMock.map(entry => entry.metric));
+    const synthetic = island
+      ? METRIC_NAMES.filter(metric => !existing.has(metric))
+          .map(metric => {
+            const snapshot = getMockSnapshotMetric(island, metric);
+            return snapshot === null ? null : buildSyntheticSeries(metric, snapshot, window);
+          })
+          .filter((entry): entry is MetricSeries => entry !== null)
+      : [];
+
+    const series = [...fromMock, ...synthetic];
+    globalCache.set(cacheKey, series, ttlForWindow(window));
+    return series;
+  }
+
+  const bucketSlug = toBucketSlug(toBucket(window));
+  const series = await Promise.all(
+    METRIC_NAMES.map(async metric => {
+      const metricSlug = toMetricSlug(metric);
+      const url = new URL(`/ecosystem/v1/islands/${encodeURIComponent(code)}/metrics/${bucketSlug}/${metricSlug}`, FORTNITE_API_BASE);
+      const response = await fetch(url.toString());
+      if (!response.ok) {
+        return {
+          metric,
+          points: []
+        } satisfies MetricSeries;
+      }
+
+      const body = (await response.json()) as any;
+      const rawPoints = body.series || body.data || body.points || body.intervals || [];
+      return {
+        metric,
+        points: Array.isArray(rawPoints)
+          ? rawPoints.map((point: any) => ({
+              ts: point.timestamp || point.ts || point.time || point[0],
+              value: Number(point.value ?? point.v ?? point[1] ?? 0)
+            }))
+          : []
+      } satisfies MetricSeries;
+    })
+  );
+
+  globalCache.set(cacheKey, series, ttlForWindow(window));
+  return series;
+}
+
+async function fetchIslandsPage(url: URL): Promise<{ items: any[]; nextUrl: URL | null }> {
+  const response = await fetch(url.toString());
+  if (!response.ok) {
+    throw new Error(`Upstream islands page failed: ${response.status}`);
+  }
+
+  const body = (await response.json()) as any;
+  const items = (body.items || body.data || []) as any[];
+  const next = body.next || body.nextUrl || body.links?.next;
+  let nextUrl: URL | null = null;
+  if (typeof next === 'string') {
+    try {
+      nextUrl = new URL(next, FORTNITE_API_BASE);
+    } catch {
+      nextUrl = null;
+    }
+  }
+
+  return { items, nextUrl };
+}
+
+async function crawlAllIslands(maxPages: number, pageSize: number, search?: string): Promise<IslandBasic[]> {
+  const first = new URL('/ecosystem/v1/islands', FORTNITE_API_BASE);
+  first.searchParams.set('limit', String(pageSize));
+  if (search) {
+    first.searchParams.set('search', search);
+  }
+
+  let page = 0;
+  let currentUrl: URL | null = first;
+  const islands: IslandBasic[] = [];
+
+  while (currentUrl && page < maxPages) {
+    currentUrl.searchParams.set('page', String(page + 1));
+    const { items, nextUrl } = await fetchIslandsPage(currentUrl);
+    islands.push(...items.map(mapIsland).filter(item => item.code && item.name));
+    page += 1;
+
+    if (nextUrl) {
+      currentUrl = nextUrl;
+      continue;
+    }
+
+    if (items.length < pageSize) {
+      break;
+    }
+
+    const guess = new URL('/ecosystem/v1/islands', FORTNITE_API_BASE);
+    guess.searchParams.set('limit', String(pageSize));
+    guess.searchParams.set('page', String(page + 1));
+    if (search) {
+      guess.searchParams.set('search', search);
+    }
+    currentUrl = guess;
+  }
+
+  return islands;
+}
+
+export async function getTopIslandBasics(window: TimeWindow, limit: number, query = ''): Promise<IslandBasic[]> {
+  const normalizedQuery = query.trim().toLowerCase();
+  const cacheKey = `top:v2:${window}:${limit}:${normalizedQuery}`;
+  const cached = globalCache.get<IslandBasic[]>(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  if (USE_MOCK) {
+    const islands = await loadMockIslands();
+    const filtered = islands.filter(island => {
+      if (!normalizedQuery) return true;
+      return island.name.toLowerCase().includes(normalizedQuery) || island.code.includes(normalizedQuery);
+    });
+    const result = [...filtered]
+      .sort((left, right) => (getMockSnapshotMetric(right, 'uniquePlayers') ?? 0) - (getMockSnapshotMetric(left, 'uniquePlayers') ?? 0))
+      .slice(0, limit)
+      .map(island => ({
+        code: island.code,
+        name: island.name,
+        creator: island.creator,
+        tags: island.tags
+      }));
+    globalCache.set(cacheKey, result, ttlForWindow(window));
+    return result;
+  }
+
+  const basics = await crawlAllIslands(5, 100, normalizedQuery || undefined);
+  const ranked = await runLimited(basics, 8, async island => {
+    const metrics = await getIslandMetrics(island.code, window);
+    const uniquePlayersSeries = metrics.find(series => series.metric === 'uniquePlayers');
+    const uniquePlayersPoints = uniquePlayersSeries?.points ?? [];
+    const uniquePlayers = uniquePlayersPoints[uniquePlayersPoints.length - 1]?.value ?? 0;
+    return {
+      island,
+      uniquePlayers
+    };
+  });
+
+  const result = ranked
+    .sort((left, right) => right.uniquePlayers - left.uniquePlayers)
+    .slice(0, limit)
+    .map(entry => entry.island);
+
+  globalCache.set(cacheKey, result, ttlForWindow(window));
+  return result;
+}
+
+export async function findIslandBasic(code: string, window: TimeWindow): Promise<IslandBasic | null> {
+  if (USE_MOCK) {
+    const islands = await loadMockIslands();
+    const island = islands.find(entry => entry.code === code);
+    return island
+      ? {
+          code: island.code,
+          name: island.name,
+          creator: island.creator,
+          tags: island.tags
+        }
+      : null;
+  }
+
+  const cachedTop = await getTopIslandBasics(window, 100);
+  const topHit = cachedTop.find(island => island.code === code);
+  if (topHit) {
+    return topHit;
+  }
+
+  const results = await searchIslands({
+    window,
+    query: code,
+    limit: 5
+  });
+
+  return results.find(island => island.code === code) ?? null;
+}

--- a/functions/src/lib/hypeScore.test.ts
+++ b/functions/src/lib/hypeScore.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { computeHypeScore } from './hypeScore.js';
+
+describe('computeHypeScore', () => {
+  it('redistributes weights across available metrics', () => {
+    const result = computeHypeScore(
+      {
+        uniquePlayers: 100,
+        peakCcu: 50,
+        minutesPerPlayer: null,
+        retentionD1: null,
+        recommends: null,
+        favorites: null
+      },
+      {
+        uniquePlayers: { min: 0, max: 100 },
+        peakCcu: { min: 0, max: 100 }
+      }
+    );
+
+    const activeWeights = result.components
+      .filter(component => component.weight > 0)
+      .reduce((total, component) => total + component.weight, 0);
+
+    expect(result.availableWeight).toBe(0.46);
+    expect(activeWeights).toBeCloseTo(1, 4);
+    expect(result.missingMetrics).toContain('minutesPerPlayer');
+    expect(result.score).toBeGreaterThan(0);
+  });
+
+  it('returns zero score when every metric is missing', () => {
+    const result = computeHypeScore({}, {});
+
+    expect(result.score).toBe(0);
+    expect(result.availableWeight).toBe(0);
+    expect(result.components.every(component => component.contribution === 0)).toBe(true);
+  });
+});

--- a/functions/src/lib/hypeScore.ts
+++ b/functions/src/lib/hypeScore.ts
@@ -1,0 +1,117 @@
+import type { HypeScoreResult, IslandSummary, MetricName } from './types.js';
+
+const HYPE_WEIGHTS: Record<MetricName, number> = {
+  uniquePlayers: 0.28,
+  peakCcu: 0.18,
+  minutesPerPlayer: 0.14,
+  retentionD1: 0.16,
+  retentionD7: 0,
+  recommends: 0.12,
+  favorites: 0.12,
+  plays: 0,
+  minutesPlayed: 0
+};
+
+const HYPE_METRICS = Object.entries(HYPE_WEIGHTS)
+  .filter(([, weight]) => weight > 0)
+  .map(([metric]) => metric as MetricName);
+
+type MetricRange = {
+  min: number;
+  max: number;
+};
+
+function round(value: number, digits = 2): number {
+  const scale = 10 ** digits;
+  return Math.round(value * scale) / scale;
+}
+
+export function buildMetricRanges(summaries: IslandSummary[]): Partial<Record<MetricName, MetricRange>> {
+  const ranges: Partial<Record<MetricName, MetricRange>> = {};
+
+  for (const metric of HYPE_METRICS) {
+    const values = summaries
+      .map(summary => summary.metrics[metric].latest)
+      .filter((value): value is number => value !== null && Number.isFinite(value));
+
+    if (values.length > 0) {
+      ranges[metric] = {
+        min: Math.min(...values),
+        max: Math.max(...values)
+      };
+    }
+  }
+
+  return ranges;
+}
+
+function normalizeValue(value: number, range?: MetricRange): number {
+  if (!range) {
+    return 0;
+  }
+
+  if (range.max === range.min) {
+    return value > 0 ? 1 : 0;
+  }
+
+  return Math.max(0, Math.min(1, (value - range.min) / (range.max - range.min)));
+}
+
+export function computeHypeScore(
+  latestValues: Partial<Record<MetricName, number | null>>,
+  ranges: Partial<Record<MetricName, MetricRange>>
+): HypeScoreResult {
+  const availableMetrics = HYPE_METRICS.filter(metric => {
+    const value = latestValues[metric];
+    return typeof value === 'number' && Number.isFinite(value);
+  });
+
+  const availableWeight = availableMetrics.reduce((total, metric) => total + HYPE_WEIGHTS[metric], 0);
+
+  if (availableMetrics.length === 0 || availableWeight === 0) {
+    return {
+      score: 0,
+      availableWeight: 0,
+      missingMetrics: [...HYPE_METRICS],
+      components: HYPE_METRICS.map(metric => ({
+        metric,
+        raw: latestValues[metric] ?? null,
+        normalized: 0,
+        weight: 0,
+        contribution: 0
+      }))
+    };
+  }
+
+  const components = HYPE_METRICS.map(metric => {
+    const raw = latestValues[metric] ?? null;
+    if (raw === null || !Number.isFinite(raw)) {
+      return {
+        metric,
+        raw: null,
+        normalized: 0,
+        weight: 0,
+        contribution: 0
+      };
+    }
+
+    const weight = HYPE_WEIGHTS[metric] / availableWeight;
+    const normalized = normalizeValue(raw, ranges[metric]);
+    const contribution = normalized * weight * 100;
+
+    return {
+      metric,
+      raw,
+      normalized: round(normalized, 4),
+      weight: round(weight, 4),
+      contribution: round(contribution, 2)
+    };
+  });
+
+  return {
+    score: round(components.reduce((total, component) => total + component.contribution, 0), 2),
+    availableWeight: round(availableWeight, 4),
+    missingMetrics: HYPE_METRICS.filter(metric => !availableMetrics.includes(metric)),
+    components
+  };
+}

--- a/functions/src/lib/metrics.test.ts
+++ b/functions/src/lib/metrics.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { buildMetricSnapshot, normalizeSeries } from './metrics.js';
+
+describe('metrics utility', () => {
+  it('returns null deltas for empty series', () => {
+    const snapshot = buildMetricSnapshot([]);
+
+    expect(snapshot.latest).toBeNull();
+    expect(snapshot.previous).toBeNull();
+    expect(snapshot.latestDelta).toEqual({ absolute: null, percent: null });
+    expect(snapshot.dayDelta).toEqual({ absolute: null, percent: null });
+  });
+
+  it('calculates latest and day deltas from normalized points', () => {
+    const series = normalizeSeries('uniquePlayers', [
+      { ts: '2025-08-11T10:20:00Z', value: 20 },
+      { ts: '2025-08-11T10:00:00Z', value: 10 },
+      { ts: '2025-08-11T10:10:00Z', value: 15 }
+    ]);
+
+    expect(series).not.toBeNull();
+
+    const snapshot = buildMetricSnapshot(series!.points);
+    expect(snapshot.latest).toBe(20);
+    expect(snapshot.previous).toBe(15);
+    expect(snapshot.latestDelta).toEqual({ absolute: 5, percent: 33.33 });
+    expect(snapshot.dayDelta).toEqual({ absolute: 10, percent: 100 });
+  });
+});

--- a/functions/src/lib/metrics.ts
+++ b/functions/src/lib/metrics.ts
@@ -1,0 +1,104 @@
+import { METRIC_NAMES, type MetricDelta, type MetricName, type MetricPoint, type MetricSeries, type MetricSnapshot } from './types.js';
+
+function round(value: number, digits = 2): number {
+  const scale = 10 ** digits;
+  return Math.round(value * scale) / scale;
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  const number = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+export function normalizeMetricName(metric: string): MetricName | null {
+  const compact = metric.replace(/[-_\s]/g, '').toLowerCase();
+
+  return (
+    METRIC_NAMES.find(candidate => candidate.replace(/[A-Z]/g, chunk => chunk.toLowerCase()).toLowerCase() === compact) ??
+    METRIC_NAMES.find(candidate => candidate.toLowerCase() === compact) ??
+    ({
+      uniqueplayers: 'uniquePlayers',
+      peakccu: 'peakCcu',
+      minutesperplayer: 'minutesPerPlayer',
+      retentiond1: 'retentionD1',
+      retentiond7: 'retentionD7',
+      recommends: 'recommends',
+      favorites: 'favorites',
+      plays: 'plays',
+      minutesplayed: 'minutesPlayed'
+    } as Record<string, MetricName | undefined>)[compact] ??
+    null
+  );
+}
+
+export function normalizePoints(points: MetricPoint[]): MetricPoint[] {
+  return points
+    .map(point => ({
+      ts: point.ts,
+      value: toFiniteNumber(point.value) ?? 0
+    }))
+    .filter(point => point.ts)
+    .sort((left, right) => left.ts.localeCompare(right.ts));
+}
+
+function buildDelta(current: number | null, previous: number | null): MetricDelta {
+  if (current === null || previous === null) {
+    return { absolute: null, percent: null };
+  }
+
+  const absolute = round(current - previous);
+  const percent = previous === 0 ? null : round(((current - previous) / previous) * 100);
+  return { absolute, percent };
+}
+
+export function buildMetricSnapshot(points: MetricPoint[]): MetricSnapshot {
+  const normalized = normalizePoints(points);
+  if (normalized.length === 0) {
+    return {
+      latest: null,
+      previous: null,
+      latestDelta: { absolute: null, percent: null },
+      dayDelta: { absolute: null, percent: null },
+      points: []
+    };
+  }
+
+  const latest = normalized[normalized.length - 1] ?? null;
+  const previous = normalized.length > 1 ? normalized[normalized.length - 2] ?? null : null;
+  const first = normalized[0] ?? null;
+
+  return {
+    latest: latest?.value ?? null,
+    previous: previous?.value ?? null,
+    latestDelta: buildDelta(latest?.value ?? null, previous?.value ?? null),
+    dayDelta: buildDelta(latest?.value ?? null, first?.value ?? null),
+    points: normalized
+  };
+}
+
+export function normalizeSeries(metric: string, points: MetricPoint[]): MetricSeries | null {
+  const normalizedMetric = normalizeMetricName(metric);
+  if (!normalizedMetric) {
+    return null;
+  }
+
+  return {
+    metric: normalizedMetric,
+    points: normalizePoints(points)
+  };
+}
+
+export function createEmptyMetricSnapshots(): Record<MetricName, MetricSnapshot> {
+  return METRIC_NAMES.reduce<Record<MetricName, MetricSnapshot>>((accumulator, metric) => {
+    accumulator[metric] = buildMetricSnapshot([]);
+    return accumulator;
+  }, {} as Record<MetricName, MetricSnapshot>);
+}
+
+export function buildMetricSnapshots(seriesList: MetricSeries[]): Record<MetricName, MetricSnapshot> {
+  const snapshots = createEmptyMetricSnapshots();
+  for (const series of seriesList) {
+    snapshots[series.metric] = buildMetricSnapshot(series.points);
+  }
+  return snapshots;
+}

--- a/functions/src/lib/overview.ts
+++ b/functions/src/lib/overview.ts
@@ -1,0 +1,44 @@
+import { buildRelated, toRanked } from './summary.js';
+import { METRIC_NAMES, type IslandOverviewResponse, type IslandSummary, type TimeWindow } from './types.js';
+
+export function buildOverviewResponse(params: {
+  target: IslandSummary;
+  candidates: IslandSummary[];
+  window: TimeWindow;
+  researchConfigured: boolean;
+}): IslandOverviewResponse {
+  const target = params.target;
+
+  return {
+    window: params.window,
+    island: toRanked(target),
+    kpis: {
+      hypeScore: target.hypeScore.score,
+      uniquePlayers: target.metrics.uniquePlayers.latest,
+      peakCcu: target.metrics.peakCcu.latest,
+      minutesPerPlayer: target.metrics.minutesPerPlayer.latest,
+      retentionD1: target.metrics.retentionD1.latest,
+      retentionD7: target.metrics.retentionD7.latest,
+      recommends: target.metrics.recommends.latest,
+      favorites: target.metrics.favorites.latest,
+      plays: target.metrics.plays.latest,
+      minutesPlayed: target.metrics.minutesPlayed.latest
+    },
+    deltas: Object.fromEntries(
+      METRIC_NAMES.map(metric => [
+        metric,
+        {
+          latest: target.metrics[metric].latestDelta,
+          day: target.metrics[metric].dayDelta
+        }
+      ])
+    ) as IslandOverviewResponse['deltas'],
+    related: buildRelated(target, params.candidates, 6),
+    researchStatus: {
+      available: params.researchConfigured,
+      configured: params.researchConfigured
+    },
+    updatedAt: target.updatedAt,
+    degraded: target.partial
+  };
+}

--- a/functions/src/lib/research.ts
+++ b/functions/src/lib/research.ts
@@ -1,0 +1,161 @@
+import fetch from 'node-fetch';
+import { globalCache } from '../cache.js';
+
+export function buildPerplexityPrompts(lang: string, titlePart: string) {
+  const system =
+    lang === 'ja'
+      ? 'あなたはFortniteの島について短く要点をまとめるリサーチアシスタントです。出力は厳密にMarkdownの見出しと箇条書きを守り、事実に基づき、必ずURL付きの出典を提示してください。YouTube、Reddit、Epic/公式ドキュメントを優先し、信頼性の低いソースは避けてください。'
+      : 'You are a concise research assistant for Fortnite islands. Output must strictly follow the requested Markdown sections with bullet points, be factual, and include URL-cited sources. Prefer YouTube, Reddit, and Epic/official documentation; avoid low-quality sources.';
+
+  const user =
+    lang === 'ja'
+      ? `次の島についてリサーチし、以下のMarkdownフォーマット（見出し名は必ずこの通り）で短く要約してください。島名とコード: ${titlePart}
+
+## Island Status
+### 状況
+- （現在の状況・コミュニティでの注目点を簡潔に）
+### 概要
+- （島のタイプ/目的/プレイ要素など）
+### 特徴
+- （主要な特徴・差別化要因）
+### 話題
+- （最近の話題・アップデート・SNS/コミュニティ動向）
+
+## 出典
+- （URL）
+- （URL）
+
+厳守事項:
+- 上記の見出し・順序・箇条書きを厳密に維持。
+- 誤検出を避けるため、島コードと一致しない情報は除外。
+- 出典はYouTube、Reddit、Epic/公式ドキュメントを優先。該当がない場合のみその他の信頼できるサイトを使用。`
+      : `Research the island: ${titlePart}
+
+Strictly output the following Markdown (use these exact headings):
+
+## Island Status
+### Status
+- (current traction/community buzz, concise)
+### Overview
+- (type/purpose/core gameplay)
+### Features
+- (key differentiators)
+### Discussion
+- (recent updates/community threads/social mentions)
+
+## Sources
+- (URL)
+- (URL)
+
+Requirements:
+- Keep the exact headings/order/bullets.
+- Exclude mismatching info (must match the island code).
+- Prefer sources from YouTube, Reddit, and Epic/official docs; use other reputable sites only if necessary.`;
+
+  return { system, user };
+}
+
+export async function fetchResearch(params: {
+  code: string;
+  name?: string;
+  lang?: string;
+}): Promise<{ summary: string; highlights: string[]; sources: Array<{ url: string; title?: string }>; updatedAt: string }> {
+  const apiKey = process.env.PERPLEXITY_API_KEY;
+  if (!apiKey) {
+    throw new Error('PERPLEXITY_API_KEY not configured');
+  }
+
+  const name = params.name ?? '';
+  const lang = params.lang ?? 'ja';
+  const cacheKey = `research:v1:${params.code}:${lang}:${name}`;
+  const cached = globalCache.get<Awaited<ReturnType<typeof fetchResearch>>>(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const titlePart = name ? `${name} (${params.code})` : params.code;
+  const { system, user } = buildPerplexityPrompts(lang, titlePart);
+  const preferred = (process.env.PERPLEXITY_MODEL || '').trim();
+  const candidates = [
+    preferred,
+    'pplx-70b-online',
+    'pplx-7b-online',
+    'sonar-large-online',
+    'sonar-medium-online',
+    'sonar-small-online',
+    'pplx-70b',
+    'pplx-7b',
+    'sonar-large-chat',
+    'sonar-medium-chat',
+    'sonar-small-chat'
+  ].filter(Boolean);
+
+  let content = '';
+  let lastError = 'unknown error';
+
+  for (const model of candidates) {
+    const response = await fetch('https://api.perplexity.ai/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: 'system', content: system },
+          { role: 'user', content: user }
+        ],
+        temperature: 0.2,
+        top_p: 0.9
+      })
+    });
+
+    let body: any = null;
+    try {
+      body = await response.json();
+    } catch {
+      body = null;
+    }
+
+    if (!response.ok) {
+      const errorType = body?.error?.type || 'error';
+      const errorMessage = body?.error?.message || `HTTP ${response.status}`;
+      lastError = `${model}: ${errorType}: ${errorMessage}`;
+      if (errorType === 'invalid_model') {
+        continue;
+      }
+      break;
+    }
+
+    content = body?.choices?.[0]?.message?.content || '';
+    if (content) {
+      lastError = '';
+      break;
+    }
+    lastError = `${model}: empty content`;
+  }
+
+  if (!content) {
+    throw new Error(`Perplexity API failed (model resolution): ${lastError}`);
+  }
+
+  const lines = String(content).split(/\r?\n/);
+  const highlights = lines
+    .filter(line => /^-\s/.test(line))
+    .map(line => line.replace(/^-\s*/, '').trim())
+    .filter(Boolean)
+    .slice(0, 6);
+
+  const urlRegex = /(https?:\/\/[^\s)]+)/g;
+  const sources = Array.from(new Set((content.match(urlRegex) || []).map(url => url.trim()))).map(url => ({ url }));
+  const result = {
+    summary: content,
+    highlights,
+    sources,
+    updatedAt: new Date().toISOString()
+  };
+
+  globalCache.set(cacheKey, result, 600);
+  return result;
+}

--- a/functions/src/lib/service.ts
+++ b/functions/src/lib/service.ts
@@ -1,0 +1,107 @@
+import { globalCache } from '../cache.js';
+import { buildCompareResponse } from './compare.js';
+import { buildDashboardResponse } from './dashboard.js';
+import { getIslandMetrics, getTopIslandBasics, findIslandBasic } from './fortnite.js';
+import { buildOverviewResponse } from './overview.js';
+import { applyHypeScores, buildIslandSummary } from './summary.js';
+import type { CompareResponse, DashboardResponse, IslandOverviewResponse, IslandSummary, SummarySortKey, TimeWindow } from './types.js';
+import { ttlForWindow } from './windows.js';
+
+async function buildSummaries(window: TimeWindow): Promise<IslandSummary[]> {
+  const basics = await getTopIslandBasics(window, 100);
+  const summaries = await Promise.all(
+    basics.map(async basic => {
+      const series = await getIslandMetrics(basic.code, window);
+      return buildIslandSummary(basic, series);
+    })
+  );
+
+  return applyHypeScores(summaries);
+}
+
+export async function getWindowSummaries(window: TimeWindow): Promise<IslandSummary[]> {
+  const cacheKey = `dashboard-base:v2:${window}`;
+  const cached = globalCache.get<IslandSummary[]>(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const summaries = await buildSummaries(window);
+  globalCache.set(cacheKey, summaries, ttlForWindow(window));
+  return summaries;
+}
+
+export async function getDashboard(params: {
+  window: TimeWindow;
+  sort: SummarySortKey;
+  tags?: string[];
+  creator?: string;
+}): Promise<DashboardResponse> {
+  const summaries = await getWindowSummaries(params.window);
+  return buildDashboardResponse({
+    summaries,
+    window: params.window,
+    sort: params.sort,
+    tags: params.tags,
+    creator: params.creator
+  });
+}
+
+export async function getIslandOverview(params: {
+  code: string;
+  window: TimeWindow;
+  researchConfigured: boolean;
+}): Promise<IslandOverviewResponse> {
+  const summaries = await getWindowSummaries(params.window);
+  let target = summaries.find(summary => summary.code === params.code) ?? null;
+
+  if (!target) {
+    const basic = (await findIslandBasic(params.code, params.window)) ?? {
+      code: params.code,
+      name: params.code,
+      creator: 'Unknown',
+      tags: []
+    };
+    const series = await getIslandMetrics(params.code, params.window);
+    target = applyHypeScores([buildIslandSummary(basic, series)])[0];
+  }
+
+  return buildOverviewResponse({
+    target,
+    candidates: summaries,
+    window: params.window,
+    researchConfigured: params.researchConfigured
+  });
+}
+
+export async function getCompare(params: {
+  codes: string[];
+  window: TimeWindow;
+}): Promise<CompareResponse> {
+  const requestedCodes = [...new Set(params.codes)].slice(0, 4);
+  const summaries = await getWindowSummaries(params.window);
+  const found = new Map(summaries.map(summary => [summary.code, summary]));
+
+  const islands = await Promise.all(
+    requestedCodes.map(async code => {
+      const existing = found.get(code);
+      if (existing) {
+        return existing;
+      }
+
+      const basic = (await findIslandBasic(code, params.window)) ?? {
+        code,
+        name: code,
+        creator: 'Unknown',
+        tags: []
+      };
+      const series = await getIslandMetrics(code, params.window);
+      return applyHypeScores([buildIslandSummary(basic, series)])[0];
+    })
+  );
+
+  return buildCompareResponse({
+    items: islands,
+    window: params.window
+  });
+}

--- a/functions/src/lib/summary.ts
+++ b/functions/src/lib/summary.ts
@@ -1,0 +1,144 @@
+import { buildMetricRanges, computeHypeScore } from './hypeScore.js';
+import { buildMetricSnapshots } from './metrics.js';
+import { METRIC_NAMES, type IslandBasic, type IslandMetricDeltas, type IslandMetricValues, type IslandSummary, type MetricName, type MetricSeries, type RankedIslandSummary, type SummarySortKey } from './types.js';
+
+function round(value: number, digits = 2): number {
+  const scale = 10 ** digits;
+  return Math.round(value * scale) / scale;
+}
+
+export function buildIslandSummary(basic: IslandBasic, seriesList: MetricSeries[]): IslandSummary {
+  const metrics = buildMetricSnapshots(seriesList);
+  const latestValues = Object.fromEntries(
+    METRIC_NAMES.map(metric => [metric, metrics[metric].latest])
+  ) as Partial<Record<MetricName, number | null>>;
+
+  const timestamps = seriesList.flatMap(series => series.points.map(point => point.ts)).sort();
+  const updatedAt = timestamps.length > 0 ? timestamps[timestamps.length - 1] ?? new Date().toISOString() : new Date().toISOString();
+  const populatedMetricCount = METRIC_NAMES.filter(metric => metrics[metric].points.length > 0).length;
+  const hypeScore = computeHypeScore(latestValues, {});
+
+  return {
+    ...basic,
+    metrics,
+    hypeScore,
+    updatedAt,
+    partial: populatedMetricCount < 4
+  };
+}
+
+export function applyHypeScores(summaries: IslandSummary[]): IslandSummary[] {
+  const ranges = buildMetricRanges(summaries);
+  return summaries.map(summary => {
+    const latestValues = Object.fromEntries(
+      METRIC_NAMES.map(metric => [metric, summary.metrics[metric].latest])
+    ) as Partial<Record<MetricName, number | null>>;
+
+    return {
+      ...summary,
+      hypeScore: computeHypeScore(latestValues, ranges)
+    };
+  });
+}
+
+function toRankedSummary(summary: IslandSummary): RankedIslandSummary {
+  const metrics = Object.fromEntries(
+    METRIC_NAMES.map(metric => [metric, summary.metrics[metric].latest])
+  ) as IslandMetricValues;
+
+  const deltas = Object.fromEntries(
+    METRIC_NAMES.map(metric => [
+      metric,
+      {
+        latest: summary.metrics[metric].latestDelta,
+        day: summary.metrics[metric].dayDelta
+      }
+    ])
+  ) as IslandMetricDeltas;
+
+  return {
+    code: summary.code,
+    name: summary.name,
+    creator: summary.creator,
+    tags: summary.tags,
+    hypeScore: summary.hypeScore.score,
+    metrics,
+    deltas,
+    hypeBreakdown: summary.hypeScore.components,
+    updatedAt: summary.updatedAt,
+    partial: summary.partial
+  };
+}
+
+function sortValue(summary: IslandSummary, sort: SummarySortKey): number {
+  if (sort === 'hype') return summary.hypeScore.score;
+  if (sort === 'latestChange') return summary.metrics.uniquePlayers.latestDelta.percent ?? Number.NEGATIVE_INFINITY;
+  return summary.metrics[sort].latest ?? Number.NEGATIVE_INFINITY;
+}
+
+export function sortSummaries(summaries: IslandSummary[], sort: SummarySortKey): IslandSummary[] {
+  return [...summaries].sort((left, right) => sortValue(right, sort) - sortValue(left, sort));
+}
+
+export function filterSummaries(summaries: IslandSummary[], tags: string[], creator: string): IslandSummary[] {
+  const normalizedCreator = creator.trim().toLowerCase();
+  return summaries.filter(summary => {
+    const matchesTags = tags.length === 0 || tags.every(tag => summary.tags.includes(tag));
+    const matchesCreator = normalizedCreator.length === 0 || summary.creator.toLowerCase().includes(normalizedCreator);
+    return matchesTags && matchesCreator;
+  });
+}
+
+export function rankSummaries(summaries: IslandSummary[], sort: SummarySortKey): RankedIslandSummary[] {
+  return sortSummaries(summaries, sort).map(toRankedSummary);
+}
+
+export function pickTopRanked(summaries: IslandSummary[], sort: SummarySortKey, limit = 20): RankedIslandSummary[] {
+  return rankSummaries(summaries, sort).slice(0, limit);
+}
+
+export function risingRanked(summaries: IslandSummary[], limit = 20): RankedIslandSummary[] {
+  return [...summaries]
+    .sort(
+      (left, right) =>
+        (right.metrics.uniquePlayers.latestDelta.percent ?? Number.NEGATIVE_INFINITY) -
+        (left.metrics.uniquePlayers.latestDelta.percent ?? Number.NEGATIVE_INFINITY)
+    )
+    .map(toRankedSummary)
+    .slice(0, limit);
+}
+
+export function retentionRanked(summaries: IslandSummary[], limit = 10): RankedIslandSummary[] {
+  return [...summaries]
+    .sort((left, right) => (right.metrics.retentionD1.latest ?? Number.NEGATIVE_INFINITY) - (left.metrics.retentionD1.latest ?? Number.NEGATIVE_INFINITY))
+    .map(toRankedSummary)
+    .slice(0, limit);
+}
+
+export function recommendRanked(summaries: IslandSummary[], limit = 10): RankedIslandSummary[] {
+  return [...summaries]
+    .sort((left, right) => (right.metrics.recommends.latest ?? Number.NEGATIVE_INFINITY) - (left.metrics.recommends.latest ?? Number.NEGATIVE_INFINITY))
+    .map(toRankedSummary)
+    .slice(0, limit);
+}
+
+export function buildRelated(target: IslandSummary, candidates: IslandSummary[], limit = 6): RankedIslandSummary[] {
+  return candidates
+    .filter(candidate => candidate.code !== target.code)
+    .map(candidate => {
+      const sharedTags = candidate.tags.filter(tag => target.tags.includes(tag)).length;
+      const sameCreator = candidate.creator === target.creator ? 2 : 0;
+      const score = round(sharedTags * 10 + sameCreator * 10 + candidate.hypeScore.score, 2);
+      return {
+        candidate,
+        score
+      };
+    })
+    .sort((left, right) => right.score - left.score)
+    .slice(0, limit)
+    .map(entry => toRankedSummary(entry.candidate));
+}
+
+export function toRanked(summary: IslandSummary): RankedIslandSummary {
+  return toRankedSummary(summary);
+}

--- a/functions/src/lib/types.ts
+++ b/functions/src/lib/types.ts
@@ -1,0 +1,149 @@
+export const TIME_WINDOWS = ['10m', '1h', '24h'] as const;
+export type TimeWindow = (typeof TIME_WINDOWS)[number];
+
+export const METRIC_NAMES = [
+  'uniquePlayers',
+  'peakCcu',
+  'minutesPerPlayer',
+  'retentionD1',
+  'retentionD7',
+  'recommends',
+  'favorites',
+  'plays',
+  'minutesPlayed'
+] as const;
+
+export type MetricName = (typeof METRIC_NAMES)[number];
+
+export type SummarySortKey =
+  | 'hype'
+  | 'uniquePlayers'
+  | 'peakCcu'
+  | 'minutesPerPlayer'
+  | 'retentionD1'
+  | 'recommends'
+  | 'favorites'
+  | 'latestChange';
+
+export type Bucket = 'TEN_MINUTE' | 'HOUR' | 'DAY';
+
+export type MetricPoint = {
+  ts: string;
+  value: number;
+};
+
+export type MetricSeries = {
+  metric: MetricName;
+  points: MetricPoint[];
+};
+
+export type MetricDelta = {
+  absolute: number | null;
+  percent: number | null;
+};
+
+export type MetricSnapshot = {
+  latest: number | null;
+  previous: number | null;
+  latestDelta: MetricDelta;
+  dayDelta: MetricDelta;
+  points: MetricPoint[];
+};
+
+export type HypeScoreComponent = {
+  metric: MetricName;
+  raw: number | null;
+  normalized: number;
+  weight: number;
+  contribution: number;
+};
+
+export type HypeScoreResult = {
+  score: number;
+  availableWeight: number;
+  missingMetrics: MetricName[];
+  components: HypeScoreComponent[];
+};
+
+export type IslandBasic = {
+  code: string;
+  name: string;
+  creator: string;
+  tags: string[];
+};
+
+export type IslandSummary = IslandBasic & {
+  metrics: Record<MetricName, MetricSnapshot>;
+  hypeScore: HypeScoreResult;
+  updatedAt: string;
+  partial: boolean;
+};
+
+export type IslandMetricValues = Record<MetricName, number | null>;
+
+export type IslandMetricDeltas = Record<
+  MetricName,
+  {
+    latest: MetricDelta;
+    day: MetricDelta;
+  }
+>;
+
+export type RankedIslandSummary = IslandBasic & {
+  hypeScore: number;
+  metrics: IslandMetricValues;
+  deltas: IslandMetricDeltas;
+  hypeBreakdown: HypeScoreComponent[];
+  updatedAt: string;
+  partial: boolean;
+};
+
+export type DashboardResponse = {
+  window: TimeWindow;
+  ranking: RankedIslandSummary[];
+  rising: RankedIslandSummary[];
+  highRetention: RankedIslandSummary[];
+  highRecommend: RankedIslandSummary[];
+  facets: {
+    tags: string[];
+    creators: string[];
+  };
+  updatedAt: string;
+  degraded: boolean;
+};
+
+export type IslandKpis = IslandMetricValues & {
+  hypeScore: number;
+};
+
+export type IslandOverviewResponse = {
+  window: TimeWindow;
+  island: RankedIslandSummary;
+  kpis: IslandKpis;
+  deltas: IslandMetricDeltas;
+  related: RankedIslandSummary[];
+  researchStatus: {
+    available: boolean;
+    configured: boolean;
+  };
+  updatedAt: string;
+  degraded: boolean;
+};
+
+export type CompareMetricSeries = {
+  metric: MetricName;
+  series: Array<{
+    code: string;
+    name: string;
+    points: MetricPoint[];
+  }>;
+};
+
+export type CompareResponse = {
+  window: TimeWindow;
+  codes: string[];
+  islands: RankedIslandSummary[];
+  metrics: CompareMetricSeries[];
+  updatedAt: string;
+  degraded: boolean;
+};

--- a/functions/src/lib/windows.ts
+++ b/functions/src/lib/windows.ts
@@ -1,0 +1,40 @@
+import type { Bucket, MetricName, TimeWindow } from './types.js';
+
+export function toBucket(window: TimeWindow): Bucket {
+  if (window === '10m') return 'TEN_MINUTE';
+  if (window === '1h') return 'HOUR';
+  return 'DAY';
+}
+
+export function toBucketSlug(bucket: Bucket): 'ten-minute' | 'hour' | 'day' {
+  if (bucket === 'TEN_MINUTE') return 'ten-minute';
+  if (bucket === 'HOUR') return 'hour';
+  return 'day';
+}
+
+export function toMetricSlug(metric: MetricName): string {
+  const map: Record<MetricName, string> = {
+    uniquePlayers: 'unique-players',
+    peakCcu: 'peak-ccu',
+    minutesPerPlayer: 'minutes-per-player',
+    retentionD1: 'retention-d1',
+    retentionD7: 'retention-d7',
+    recommends: 'recommends',
+    favorites: 'favorites',
+    plays: 'plays',
+    minutesPlayed: 'minutes-played'
+  };
+
+  return map[metric];
+}
+
+export function ttlForWindow(window: TimeWindow): number {
+  if (window === '10m') return 600;
+  return 900;
+}
+
+export function windowStepMs(window: TimeWindow): number {
+  if (window === '10m') return 10 * 60 * 1000;
+  if (window === '1h') return 60 * 60 * 1000;
+  return 6 * 60 * 60 * 1000;
+}


### PR DESCRIPTION
## Summary
- split backend v2 data shaping into lib modules
- add dashboard/overview/compare contracts and utility tests
- establish functions-side foundation for the v2 dashboard work

## Notes
- this branch is a backend foundation worktree and is superseded by the integrated implementation in #6
- opened as draft to preserve the worktree branch without implying it is the preferred merge target

## Testing
- not re-run in this branch during PR creation flow