### PR TITLE
test: add Firebase smoke E2E suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ E2E:
 npm run test:e2e
 ```
 
+Firebase / deployed smoke E2E:
+
+```bash
+npm run test:e2e:smoke
+npm run test:e2e:firebase
+```
+
 ### デプロイ
 
 Hosting のみ:
@@ -173,4 +180,4 @@ firebase deploy
 
 - dashboard 系は `window` 単位でキャッシュし、検索は `/api/islands` に分離しています。
 - compare / watchlist / recent state は `localStorage` に保持します。
-- 主要導線は `Home` / `IslandDetail` / `Compare` / `Watchlist persistence` の E2E で検証しています。
+- `npm run test:e2e` は mock fixture 前提の回帰 E2E、`npm run test:e2e:firebase` は Firebase 上の live data に追従する smoke E2E です。

--- a/README.md
+++ b/README.md
@@ -147,10 +147,15 @@ E2E:
 npm run test:e2e
 ```
 
-Firebase / deployed smoke E2E:
+Local smoke E2E:
 
 ```bash
 npm run test:e2e:smoke
+```
+
+Firebase / deployed smoke E2E:
+
+```bash
 npm run test:e2e:firebase
 ```
 
@@ -180,4 +185,5 @@ firebase deploy
 
 - dashboard 系は `window` 単位でキャッシュし、検索は `/api/islands` に分離しています。
 - compare / watchlist / recent state は `localStorage` に保持します。
-- `npm run test:e2e` は mock fixture 前提の回帰 E2E、`npm run test:e2e:firebase` は Firebase 上の live data に追従する smoke E2E です。
+- `npm run test:e2e` は mock fixture 前提の回帰 E2E、`npm run test:e2e:smoke` は local preview + mock functions を使う smoke E2E です。
+- `npm run test:e2e:firebase` は Firebase 上の live data に追従する smoke E2E です。

--- a/e2e-smoke/firebase-smoke.spec.ts
+++ b/e2e-smoke/firebase-smoke.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test';
+import { desktopRow, fetchSmokeSelection, installClipboardStub, mobileCard } from './support';
+
+test.beforeEach(async ({ page }) => {
+  await installClipboardStub(page);
+});
+
+test('desktop smoke keeps home, compare, and detail usable with live data', async ({ page }) => {
+  const [first, second] = await fetchSmokeSelection(page);
+
+  await page.goto('/?window=24h&view=table');
+
+  await expect(page.getByRole('heading', { name: /See what is strong/i })).toBeVisible();
+  await expect(page.locator('.islands-table')).toBeVisible();
+
+  const firstRow = desktopRow(page, first.code);
+  const secondRow = desktopRow(page, second.code);
+
+  await expect(firstRow).toBeVisible();
+  await expect(secondRow).toBeVisible();
+
+  await firstRow.getByRole('button', { name: 'Add Compare' }).click();
+  await secondRow.getByRole('button', { name: 'Add Compare' }).click();
+  await expect(page.getByRole('link', { name: 'Open Compare' })).toBeVisible();
+
+  await page.getByRole('link', { name: 'Open Compare' }).click();
+  await expect(page).toHaveURL(/\/compare\?codes=/);
+
+  const matrixTable = page.locator('.compare-table').first();
+  await expect(matrixTable.getByRole('columnheader', { name: first.name })).toBeVisible();
+  await expect(matrixTable.getByRole('columnheader', { name: second.name })).toBeVisible();
+
+  await page.goto(`/island/${first.code}?name=${encodeURIComponent(first.name)}&window=24h`);
+
+  await expect(page.locator('h1')).toHaveText(first.name);
+  await expect(page.getByText('Island overview')).toBeVisible();
+  await expect(page.locator('.kpi-grid .kpi-card').first()).toBeVisible();
+  await expect(page.locator('.chart-card')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Keep exploring' })).toBeVisible();
+});
+
+test.describe('mobile smoke', () => {
+  test.use({
+    viewport: { width: 390, height: 844 }
+  });
+
+  test('mobile cards, detail, and compare stay usable with live data', async ({ page }) => {
+    const [first, second] = await fetchSmokeSelection(page);
+
+    await page.goto('/?window=24h');
+
+    await expect(page.getByRole('heading', { name: /See what is strong/i })).toBeVisible();
+    await expect(page.locator('.ranking-card').first()).toBeVisible();
+    await expect(page.locator('.islands-table')).toHaveCount(0);
+
+    const firstCard = mobileCard(page, first.code);
+    const secondCard = mobileCard(page, second.code);
+
+    await expect(firstCard).toBeVisible();
+    await expect(secondCard).toBeVisible();
+
+    await firstCard.getByRole('button', { name: 'Watchlist' }).click();
+    await expect(page.getByRole('status')).toContainText('saved to watchlist');
+
+    await firstCard.getByRole('button', { name: 'Add Compare' }).click();
+    await secondCard.getByRole('button', { name: 'Add Compare' }).click();
+    await expect(page.getByRole('link', { name: 'Open Compare' })).toBeVisible();
+
+    await firstCard.getByRole('link', { name: first.name }).click();
+    await expect(page).toHaveURL(new RegExp(`/island/${first.code}`));
+    await expect(page.locator('.hero-panel--detail .action-row').first()).toBeVisible();
+    await expect(page.locator('.chart-card')).toBeVisible();
+
+    await page.goBack();
+    await page.getByRole('link', { name: 'Open Compare' }).click();
+    await expect(page).toHaveURL(/\/compare\?codes=/);
+
+    const matrixTable = page.locator('.compare-table').first();
+    await expect(matrixTable.getByRole('columnheader', { name: first.name })).toBeVisible();
+    await expect(matrixTable.getByRole('columnheader', { name: second.name })).toBeVisible();
+  });
+});

--- a/e2e-smoke/support.ts
+++ b/e2e-smoke/support.ts
@@ -10,6 +10,8 @@ type DashboardResponse = {
   rising?: DashboardIsland[];
 };
 
+type DashboardSection = keyof Pick<DashboardResponse, 'ranking' | 'rising'>;
+
 export async function installClipboardStub(page: Page) {
   await page.addInitScript(() => {
     Object.defineProperty(navigator, 'clipboard', {
@@ -21,13 +23,20 @@ export async function installClipboardStub(page: Page) {
   });
 }
 
-export async function fetchSmokeSelection(page: Page, count = 2): Promise<DashboardIsland[]> {
+export async function fetchSmokeSelection(
+  page: Page,
+  options: {
+    count?: number;
+    source?: DashboardSection;
+  } = {}
+): Promise<DashboardIsland[]> {
+  const { count = 2, source = 'ranking' } = options;
   const response = await page.request.get('/api/dashboard?window=24h');
   expect(response.ok()).toBeTruthy();
 
   const data = (await response.json()) as DashboardResponse;
   const seen = new Set<string>();
-  const islands = [...(data.ranking ?? []), ...(data.rising ?? [])].filter((item): item is DashboardIsland => {
+  const islands = (data[source] ?? []).filter((item): item is DashboardIsland => {
     if (!item?.code || !item?.name || seen.has(item.code)) {
       return false;
     }

--- a/e2e-smoke/support.ts
+++ b/e2e-smoke/support.ts
@@ -1,0 +1,48 @@
+import { expect, type Page } from '@playwright/test';
+
+type DashboardIsland = {
+  code: string;
+  name: string;
+};
+
+type DashboardResponse = {
+  ranking?: DashboardIsland[];
+  rising?: DashboardIsland[];
+};
+
+export async function installClipboardStub(page: Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: async () => undefined
+      }
+    });
+  });
+}
+
+export async function fetchSmokeSelection(page: Page, count = 2): Promise<DashboardIsland[]> {
+  const response = await page.request.get('/api/dashboard?window=24h');
+  expect(response.ok()).toBeTruthy();
+
+  const data = (await response.json()) as DashboardResponse;
+  const seen = new Set<string>();
+  const islands = [...(data.ranking ?? []), ...(data.rising ?? [])].filter((item): item is DashboardIsland => {
+    if (!item?.code || !item?.name || seen.has(item.code)) {
+      return false;
+    }
+    seen.add(item.code);
+    return true;
+  });
+
+  expect(islands.length).toBeGreaterThanOrEqual(count);
+  return islands.slice(0, count);
+}
+
+export function desktopRow(page: Page, code: string) {
+  return page.locator('.islands-table tbody tr', { hasText: code }).first();
+}
+
+export function mobileCard(page: Page, code: string) {
+  return page.locator('.ranking-card', { hasText: code }).first();
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "scripts": {
     "test:e2e": "playwright test",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:smoke": "playwright test --config=playwright.smoke.config.ts",
+    "test:e2e:firebase": "PLAYWRIGHT_BASE_URL=https://fortnite-island-ranking.web.app playwright test --config=playwright.smoke.config.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2"

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from '@playwright/test';
+
+const remoteBaseUrl = process.env.PLAYWRIGHT_BASE_URL;
+
+export default defineConfig({
+  testDir: 'e2e-smoke',
+  fullyParallel: false,
+  timeout: 60_000,
+  workers: 1,
+  expect: {
+    timeout: 20_000
+  },
+  webServer: remoteBaseUrl
+    ? undefined
+    : [
+        {
+          command: 'npm --prefix functions run dev:mock',
+          url: 'http://127.0.0.1:5001/health',
+          reuseExistingServer: true,
+          timeout: 120_000
+        },
+        {
+          command: 'npm --prefix web run preview:e2e',
+          url: 'http://127.0.0.1:5173',
+          reuseExistingServer: true,
+          timeout: 120_000
+        }
+      ],
+  use: {
+    baseURL: remoteBaseUrl ?? 'http://127.0.0.1:5173',
+    headless: true,
+    trace: 'on-first-retry'
+  }
+});


### PR DESCRIPTION
## Summary\n- add a dedicated Playwright smoke suite for deployed or remote environments\n- keep existing mock-backed regression E2E unchanged under the default config\n- document smoke commands for Firebase validation\n\n## Verification\n- npm run test:e2e\n- npm run test:e2e:smoke\n- npm run test:e2e:firebase\n\nCloses #9