### PR TITLE
fix(web): default dashboard window to 24h

### DIFF
--- a/web/src/lib/urlState.test.tsx
+++ b/web/src/lib/urlState.test.tsx
@@ -43,7 +43,7 @@ describe('urlState', () => {
 
   it('serializes home query state without default values', () => {
     const searchParams = serializeHomeQueryState({
-      window: '10m',
+      window: '24h',
       tab: 'top',
       sort: 'hype',
       query: 'battle',

--- a/web/src/lib/urlState.ts
+++ b/web/src/lib/urlState.ts
@@ -26,7 +26,7 @@ const SORTS: DashboardSort[] = [
 const VIEWS: DashboardView[] = ['table', 'cards'];
 
 export const DEFAULT_HOME_QUERY_STATE: HomeQueryState = {
-  window: '10m',
+  window: '24h',
   tab: 'top',
   sort: 'hype',
   query: '',
@@ -36,11 +36,11 @@ export const DEFAULT_HOME_QUERY_STATE: HomeQueryState = {
 };
 
 export const DEFAULT_DETAIL_QUERY_STATE: DetailQueryState = {
-  window: '10m'
+  window: '24h'
 };
 
 export const DEFAULT_COMPARE_QUERY_STATE: CompareQueryState = {
-  window: '10m',
+  window: '24h',
   codes: []
 };
 

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -21,7 +21,7 @@ import type {
   RecentViewEntry,
   WatchlistEntry
 } from '../lib/types';
-import { toDashboardRequest, useHomeQueryState } from '../lib/urlState';
+import { DEFAULT_HOME_QUERY_STATE, toDashboardRequest, useHomeQueryState } from '../lib/urlState';
 import { DashboardFilterBar } from '../components/DashboardFilterBar';
 import { RankingCards } from '../components/RankingCards';
 import { RankingTable } from '../components/RankingTable';
@@ -284,12 +284,7 @@ export function Home() {
   const resetFilters = () => {
     setSearchInput('');
     setQueryState({
-      window: '10m',
-      tab: 'top',
-      sort: 'hype',
-      query: '',
-      tags: [],
-      creator: '',
+      ...DEFAULT_HOME_QUERY_STATE,
       view: prefersCards ? 'cards' : 'table'
     });
   };


### PR DESCRIPTION
## Summary\n- default home, detail, and compare views to the 24h window in the web UI\n- align the Home reset action with the shared default query state\n\n## Verification\n- npm test --prefix web\n- npm run build --prefix web\n- npm test --prefix functions\n- npm run build --prefix functions\n- npm run test:e2e\n- npm run test:e2e:smoke\n- firebase deploy --project fortnite-island-ranking\n- npm run test:e2e:firebase\n\n## Production checks\n- verified https://fortnite-island-ranking.web.app/ now opens with the 24h window selected\n- verified live /api/dashboard?window=24h and /api/islands/:code/metrics?window=24h return peakCcu and favorites again