### PR TITLE
fix(functions): reduce live dashboard upstream pressure

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,6 +7,7 @@ import { buildCompareResponse, buildDashboardResponse, buildIslandOverviewRespon
 import { DASHBOARD_SORTS, TIME_WINDOWS, type DashboardSort, type DeltaValue, type HypeBreakdownComponent, type IslandSummary, type MetricKey, type MetricSnapshot, type TimeWindow } from './lib/contracts.js';
 import { fetchIslandSeries } from './lib/fortnite.js';
 import { buildPerplexityPrompts } from './lib/research.js';
+import { warmDashboardCaches } from './lib/warm.js';
 
 export const app = express();
 app.use(cors());
@@ -413,15 +414,6 @@ app.get(['/islands/:code/research', '/api/islands/:code/research'], async (req, 
 
 export const api = onRequest({ region: 'us-central1' }, app);
 
-export const warmTopIslands = onSchedule({ region: 'us-central1', schedule: 'every 10 minutes' }, async () => {
-  for (const window of TIME_WINDOWS) {
-    try {
-      await buildDashboardResponse({
-        window,
-        sort: 'hype'
-      });
-    } catch {
-      // ignore scheduler errors
-    }
-  }
+export const warmTopIslands = onSchedule({ region: 'us-central1', schedule: 'every 5 minutes' }, async () => {
+  await warmDashboardCaches();
 });

--- a/functions/src/lib/dashboard.test.ts
+++ b/functions/src/lib/dashboard.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { globalCache } from '../cache.js';
 import { buildCompareResponse, buildDashboardResponse, buildIslandOverviewResponse } from './dashboard.js';
 import type { IslandRecord, MetricKey, MetricSeries } from './contracts.js';
+
+const DASHBOARD_BASE_METRICS: MetricKey[] = [
+  'uniquePlayers',
+  'peakCcu',
+  'favorites'
+];
 
 const ISLANDS: IslandRecord[] = [
   { code: 'A', name: 'Alpha', creator: 'Creator 1', tags: ['PvP', 'Arena'] },
@@ -15,7 +22,9 @@ const SERIES: Record<string, Partial<Record<MetricKey, number[]>>> = {
     minutesPerPlayer: [12, 15],
     retentionD1: [0.2, 0.28],
     recommends: [120, 140],
-    favorites: [80, 90]
+    favorites: [80, 90],
+    plays: [200, 260],
+    minutesPlayed: [1200, 1950]
   },
   B: {
     uniquePlayers: [80, 150],
@@ -23,7 +32,9 @@ const SERIES: Record<string, Partial<Record<MetricKey, number[]>>> = {
     minutesPerPlayer: [8, 11],
     retentionD1: [0.12, 0.16],
     recommends: [100, 130],
-    favorites: [70, 72]
+    favorites: [70, 72],
+    plays: [180, 280],
+    minutesPlayed: [960, 1640]
   },
   C: {
     uniquePlayers: [60, 62],
@@ -31,7 +42,9 @@ const SERIES: Record<string, Partial<Record<MetricKey, number[]>>> = {
     minutesPerPlayer: [18, 19],
     retentionD1: [0.35, 0.37],
     recommends: [40, 45],
-    favorites: [50, 52]
+    favorites: [50, 52],
+    plays: [90, 94],
+    minutesPlayed: [1080, 1178]
   }
 };
 
@@ -58,7 +71,21 @@ const deps = {
   isResearchAvailable: () => true
 };
 
+const coreOnlyDeps = {
+  ...deps,
+  fetchIslandSeries: async (code: string) =>
+    buildSeries(code).filter((entry) => ['uniquePlayers', 'peakCcu', 'favorites'].includes(entry.metric))
+};
+
+function clearCache() {
+  ((globalCache as unknown as { store: Map<string, unknown> }).store).clear();
+}
+
 describe('dashboard builders', () => {
+  beforeEach(() => {
+    clearCache();
+  });
+
   it('returns degraded dashboards without breaking array shapes', async () => {
     const dashboard = await buildDashboardResponse({
       window: '10m',
@@ -71,12 +98,64 @@ describe('dashboard builders', () => {
     expect(dashboard.facets.tags[0]?.value).toBe('Arena');
   });
 
+  it('does not mark dashboards degraded when only optional metrics are absent', async () => {
+    const dashboard = await buildDashboardResponse({
+      window: '24h',
+      sort: 'hype'
+    }, coreOnlyDeps);
+
+    expect(dashboard.degraded).toBe(false);
+    expect(dashboard.partialFailures).toBe(0);
+    expect(dashboard.ranking[0]?.metrics.uniquePlayers).toBeGreaterThan(0);
+  });
+
+  it('requests only the dashboard base metric subset for ranking data', async () => {
+    const metricRequests: MetricKey[][] = [];
+    const trackingDeps = {
+      ...deps,
+      fetchIslandSeries: async (code: string, _window: string, metrics?: MetricKey[]) => {
+        metricRequests.push([...(metrics || [])]);
+        return buildSeries(code).filter((entry) => !metrics || metrics.includes(entry.metric));
+      }
+    };
+
+    const dashboard = await buildDashboardResponse({
+      window: '24h',
+      sort: 'hype'
+    }, trackingDeps);
+
+    expect(dashboard.ranking).toHaveLength(3);
+    expect(metricRequests).toHaveLength(3);
+    expect(metricRequests.every((request) => request.join(',') === DASHBOARD_BASE_METRICS.join(','))).toBe(true);
+  });
+
   it('builds island overview with related islands', async () => {
     const overview = await buildIslandOverviewResponse('A', '10m', deps);
     expect(overview?.island.code).toBe('A');
     expect(overview?.kpis[0]?.metric).toBe('uniquePlayers');
     expect(overview?.related.map((item) => item.code)).toContain('C');
     expect(overview?.researchStatus.available).toBe(true);
+  });
+
+  it('refetches full metrics for overview even when dashboard base is subset-cached', async () => {
+    const metricRequests: Array<{ code: string; metrics: MetricKey[] | null }> = [];
+    const trackingDeps = {
+      ...deps,
+      fetchIslandSeries: async (code: string, _window: string, metrics?: MetricKey[]) => {
+        metricRequests.push({ code, metrics: metrics ? [...metrics] : null });
+        return buildSeries(code).filter((entry) => !metrics || metrics.includes(entry.metric));
+      }
+    };
+
+    await buildDashboardResponse({
+      window: '24h',
+      sort: 'hype'
+    }, trackingDeps);
+    const overview = await buildIslandOverviewResponse('A', '24h', trackingDeps);
+
+    expect(overview?.kpis.find((snapshot) => snapshot.metric === 'plays')?.latest).toBe(260);
+    expect(metricRequests.slice(0, 3).every((request) => request.metrics?.join(',') === DASHBOARD_BASE_METRICS.join(','))).toBe(true);
+    expect(metricRequests[metricRequests.length - 1]).toEqual({ code: 'A', metrics: null });
   });
 
   it('builds compare response for selected islands', async () => {

--- a/functions/src/lib/dashboard.ts
+++ b/functions/src/lib/dashboard.ts
@@ -50,12 +50,39 @@ type DashboardBase = {
   partialFailures: number;
 };
 
+const CORE_HEALTH_METRICS = new Set<MetricKey>(['uniquePlayers', 'peakCcu', 'favorites']);
+const DASHBOARD_BASE_METRICS: MetricKey[] = [
+  'uniquePlayers',
+  'peakCcu',
+  'favorites'
+];
+const ISLAND_SUMMARY_CONCURRENCY = 2;
+
+async function mapLimited<T, R>(inputs: T[], limit: number, worker: (input: T) => Promise<R>): Promise<R[]> {
+  const size = Math.max(1, Math.min(limit, inputs.length));
+  let cursor = 0;
+  const results = new Array<R>(inputs.length);
+
+  const workers = Array.from({ length: size }, async () => {
+    while (true) {
+      const index = cursor++;
+      if (index >= inputs.length) {
+        break;
+      }
+      results[index] = await worker(inputs[index]);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
 function prepareIsland(island: IslandRecord, series: MetricSeries[]): PreparedIsland {
   const metricSeries = new Map(series.map((entry) => [entry.metric, entry.points]));
   const kpis = METRIC_KEYS.map((metric) => buildMetricSnapshot(metric, metricSeries.get(metric) || []));
   const metrics = Object.fromEntries(kpis.map((snapshot) => [snapshot.metric, snapshot.latest])) as Partial<Record<MetricKey, number | null>>;
   const deltas = Object.fromEntries(kpis.map((snapshot) => [snapshot.metric, snapshot.previousDelta])) as Partial<Record<MetricKey, DeltaValue>>;
-  const missingMetrics = kpis.filter((snapshot) => snapshot.latest === null).length;
+  const missingMetrics = kpis.filter((snapshot) => snapshot.latest === null && CORE_HEALTH_METRICS.has(snapshot.metric)).length;
 
   return {
     island,
@@ -63,6 +90,21 @@ function prepareIsland(island: IslandRecord, series: MetricSeries[]): PreparedIs
     metrics,
     deltas,
     missingMetrics
+  };
+}
+
+function rehydratePreparedIsland(summary: IslandSummary, kpis: MetricSnapshot[] = []): PreparedIsland {
+  return {
+    island: {
+      code: summary.code,
+      name: summary.name,
+      creator: summary.creator,
+      tags: summary.tags
+    },
+    kpis,
+    metrics: summary.metrics,
+    deltas: summary.deltas,
+    missingMetrics: kpis.filter((snapshot) => snapshot.latest === null && CORE_HEALTH_METRICS.has(snapshot.metric)).length
   };
 }
 
@@ -133,12 +175,12 @@ function filterSummaries(summaries: IslandSummary[], tags: string[], creator?: s
 }
 
 async function buildDashboardBase(window: TimeWindow, dependencies: DashboardDependencies): Promise<DashboardBase> {
-  const cacheKey = `dashboard:base:v2:${window}`;
+  const cacheKey = `dashboard:base:v3:${window}`;
   const cached = globalCache.get<DashboardBase>(cacheKey);
   if (cached) return cached;
 
   const islands = await dependencies.computePopularIslands(window, 24);
-  const base = await buildSummariesForIslands(islands, window, dependencies);
+  const base = await buildSummariesForIslands(islands, window, dependencies, DASHBOARD_BASE_METRICS);
   globalCache.set(cacheKey, base, 600);
   return base;
 }
@@ -146,14 +188,15 @@ async function buildDashboardBase(window: TimeWindow, dependencies: DashboardDep
 async function buildSummariesForIslands(
   islands: IslandRecord[],
   window: TimeWindow,
-  dependencies: DashboardDependencies
+  dependencies: DashboardDependencies,
+  metrics: MetricKey[] = [...METRIC_KEYS]
 ): Promise<DashboardBase> {
   const updatedAt = dependencies.now();
   let partialFailures = 0;
 
-  const prepared = await Promise.all(islands.map(async (island) => {
+  const prepared = await mapLimited(islands, ISLAND_SUMMARY_CONCURRENCY, async (island) => {
     try {
-      const series = await dependencies.fetchIslandSeries(island.code, window);
+      const series = await dependencies.fetchIslandSeries(island.code, window, metrics);
       const preparedIsland = prepareIsland(island, series);
       if (preparedIsland.missingMetrics > 0) partialFailures += 1;
       return preparedIsland;
@@ -161,7 +204,7 @@ async function buildSummariesForIslands(
       partialFailures += 1;
       return prepareIsland(island, []);
     }
-  }));
+  });
 
   const summaries = summarizePrepared(prepared, updatedAt);
   return {
@@ -218,7 +261,7 @@ export async function buildSearchResponse(
 ): Promise<DashboardBase> {
   const deps = { ...DEFAULT_DEPENDENCIES, ...dependencies };
   const islands = await deps.computePopularIslands(options.window, options.limit, options.query);
-  return buildSummariesForIslands(islands, options.window, deps);
+  return buildSummariesForIslands(islands, options.window, deps, DASHBOARD_BASE_METRICS);
 }
 
 function scoreRelated(origin: IslandSummary, candidate: IslandSummary): number {
@@ -235,47 +278,39 @@ export async function buildIslandOverviewResponse(
   dependencies: Partial<DashboardDependencies> = {}
 ): Promise<IslandOverviewResponse | null> {
   const deps = { ...DEFAULT_DEPENDENCIES, ...dependencies };
-  const cacheKey = `overview:v2:${code}:${window}`;
+  const cacheKey = `overview:v3:${code}:${window}`;
   const cached = globalCache.get<IslandOverviewResponse>(cacheKey);
   if (cached) return cached;
 
   const base = await buildDashboardBase(window, deps);
-  const existing = base.summaries.find((summary) => summary.code === code);
+  const basePrepared = base.summaries.map((summary) => rehydratePreparedIsland(summary, base.kpisByCode.get(summary.code) || []));
+  const existing = basePrepared.find((summary) => summary.island.code === code) || null;
+  const island = existing?.island || await deps.getIslandByCode(code);
+  if (!island) return null;
 
-  let islandSummary = existing || null;
-  let kpis = islandSummary ? base.kpisByCode.get(code) || [] : [];
   let degraded = base.degraded;
+  let prepared = existing;
 
-  if (!islandSummary) {
-    const island = await deps.getIslandByCode(code);
-    if (!island) return null;
-
+  try {
     const series = await deps.fetchIslandSeries(code, window);
-    const prepared = prepareIsland(island, series);
-    const mergedSummaries = summarizePrepared([
-      ...base.summaries.map((summary) => ({
-        island: {
-          code: summary.code,
-          name: summary.name,
-          creator: summary.creator,
-          tags: summary.tags
-        },
-        metrics: summary.metrics,
-        deltas: summary.deltas,
-        kpis: base.kpisByCode.get(summary.code) || [],
-        missingMetrics: 0
-      })),
-      prepared
-    ], deps.now());
-
-    islandSummary = mergedSummaries.find((summary) => summary.code === code) || null;
-    kpis = prepared.kpis;
-    degraded = degraded || prepared.missingMetrics > 0;
+    prepared = prepareIsland(island, series);
+  } catch {
+    degraded = true;
+    prepared = existing || prepareIsland(island, []);
   }
 
+  if (!prepared) return null;
+
+  degraded = degraded || prepared.missingMetrics > 0;
+  const updatedAt = deps.now();
+  const mergedSummaries = summarizePrepared([
+    ...basePrepared.filter((summary) => summary.island.code !== code),
+    prepared
+  ], updatedAt);
+  const islandSummary = mergedSummaries.find((summary) => summary.code === code) || null;
   if (!islandSummary) return null;
 
-  const related = base.summaries
+  const related = mergedSummaries
     .filter((summary) => summary.code !== islandSummary?.code)
     .sort((left, right) => scoreRelated(islandSummary!, right) - scoreRelated(islandSummary!, left))
     .slice(0, 6);
@@ -283,9 +318,9 @@ export async function buildIslandOverviewResponse(
   const response = {
     window,
     island: islandSummary,
-    kpis,
+    kpis: prepared.kpis,
     related,
-    updatedAt: islandSummary.updatedAt,
+    updatedAt,
     degraded,
     researchStatus: {
       available: deps.isResearchAvailable()

--- a/functions/src/lib/fortnite.test.ts
+++ b/functions/src/lib/fortnite.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { globalCache } from '../cache.js';
+
+const { fetchMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn()
+}));
+
+vi.mock('node-fetch', () => ({
+  default: fetchMock
+}));
+
+import { computePopularIslands, fetchIslandSeries } from './fortnite.js';
+
+function clearCache() {
+  ((globalCache as unknown as { store: Map<string, unknown> }).store).clear();
+}
+
+function response(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body)
+  };
+}
+
+function uniquePlayersSeries(value: number) {
+  return response(200, {
+    intervals: [
+      {
+        timestamp: '2025-01-01T00:00:00.000Z',
+        value
+      }
+    ]
+  });
+}
+
+describe('fortnite upstream fallbacks', () => {
+  beforeEach(() => {
+    clearCache();
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearCache();
+  });
+
+  it('retries a throttled islands page before ranking candidates', async () => {
+    let firstPageAttempts = 0;
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/ecosystem/v1/islands?size=24')) {
+        firstPageAttempts += 1;
+        if (firstPageAttempts === 1) {
+          return response(429, { error: 'rate limited' });
+        }
+        return response(200, {
+          items: [
+            { code: 'A', title: 'Alpha', creator: 'Creator 1', tags: ['Arena'] },
+            { code: 'B', title: 'Bravo', creator: 'Creator 2', tags: ['Arena'] }
+          ],
+          next: null
+        });
+      }
+
+      throw new Error(`Unexpected fetch url: ${url}`);
+    });
+
+    const result = await computePopularIslands('24h', 2);
+
+    expect(firstPageAttempts).toBe(2);
+    expect(result.map((item) => item.code)).toEqual(['A', 'B']);
+  });
+
+  it('returns partial results when a later islands page keeps failing', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let secondPageAttempts = 0;
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/ecosystem/v1/islands?size=24&cursor=next')) {
+        secondPageAttempts += 1;
+        return response(429, { error: 'rate limited' });
+      }
+
+      if (url.includes('/ecosystem/v1/islands?size=24')) {
+        return response(200, {
+          items: [
+            { code: 'A', title: 'Alpha', creator: 'Creator 1', tags: ['Arena'] }
+          ],
+          next: '/ecosystem/v1/islands?size=24&cursor=next'
+        });
+      }
+
+      throw new Error(`Unexpected fetch url: ${url}`);
+    });
+
+    const result = await computePopularIslands('24h', 2);
+
+    expect(secondPageAttempts).toBe(3);
+    expect(result.map((item) => item.code)).toEqual(['A']);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'collectCatalogCandidates page fetch failed',
+      expect.objectContaining({
+        page: 2,
+        limit: 2
+      })
+    );
+  });
+
+  it('short-caches unexpected metric throttling to avoid immediate refetches', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.includes('/islands/A/metrics/day/unique-players')) {
+        return response(429, { error: 'rate limited' });
+      }
+
+      throw new Error(`Unexpected fetch url: ${url}`);
+    });
+
+    const first = await fetchIslandSeries('A', '24h', ['uniquePlayers']);
+    const second = await fetchIslandSeries('A', '24h', ['uniquePlayers']);
+
+    expect(first).toEqual([{ metric: 'uniquePlayers', points: [] }]);
+    expect(second).toEqual([{ metric: 'uniquePlayers', points: [] }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'fetchIslandSeries upstream failure',
+      expect.objectContaining({
+        code: 'A',
+        window: '24h',
+        metric: 'uniquePlayers',
+        status: 429
+      })
+    );
+  });
+});

--- a/functions/src/lib/fortnite.ts
+++ b/functions/src/lib/fortnite.ts
@@ -10,6 +10,20 @@ const USE_MOCK = process.env.USE_MOCK === '1';
 const FORTNITE_API_BASE = process.env.FORTNITE_API_BASE || 'https://api.fortnite.com';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MOCKS_DIR = path.resolve(__dirname, '../../mocks');
+const DEFAULT_CATALOG_PAGE_SIZE = 100;
+const DEFAULT_CATALOG_MAX_PAGES = 8;
+const SEARCH_CATALOG_MAX_PAGES = 4;
+const POPULAR_SCAN_PAGE_SIZE = 24;
+const POPULAR_SCAN_MAX_PAGES = 4;
+const POPULAR_TARGET_MULTIPLIER = 1.25;
+const POPULAR_MAX_SCORED_CANDIDATES = 48;
+const POPULAR_SCORE_CONCURRENCY = 1;
+const ISLANDS_PAGE_FETCH_ATTEMPTS = 3;
+const ISLANDS_PAGE_FETCH_BACKOFF_MS = 400;
+const METRIC_FETCH_CONCURRENCY = 1;
+const METRIC_FETCH_ATTEMPTS = 3;
+const SHORT_FAILURE_TTL = 60;
+const EXPECTED_MISSING_METRICS = new Set<MetricKey>(['minutesPerPlayer', 'retentionD1', 'retentionD7', 'recommends']);
 
 type RawIsland = {
   code?: string;
@@ -18,6 +32,12 @@ type RawIsland = {
   creatorCode?: string;
   creator?: string | { name?: string };
   tags?: string[];
+};
+
+type ScoredIsland = {
+  island: IslandRecord;
+  latest: number;
+  hasData: boolean;
 };
 
 async function runLimited<T>(inputs: T[], limit: number, worker: (input: T) => Promise<void>): Promise<void> {
@@ -33,6 +53,33 @@ async function runLimited<T>(inputs: T[], limit: number, worker: (input: T) => P
   });
 
   await Promise.all(workers);
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRetryableMetricFailure(metric: MetricKey, status: number) {
+  if (status === 408 || status === 425) {
+    return true;
+  }
+  if (status >= 500) {
+    return true;
+  }
+  return false;
+}
+
+function isRetryableIslandsPageFailure(status: number) {
+  return status === 403 || status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+function createIslandsUrl(pageSize: number, search?: string) {
+  const url = new URL('/ecosystem/v1/islands', FORTNITE_API_BASE);
+  url.searchParams.set('size', String(pageSize));
+  if (search) {
+    url.searchParams.set('search', search);
+  }
+  return url;
 }
 
 function toIslandRecord(raw: RawIsland): IslandRecord | null {
@@ -53,55 +100,76 @@ function toIslandRecord(raw: RawIsland): IslandRecord | null {
 }
 
 async function fetchIslandsPage(url: URL): Promise<{ items: RawIsland[]; nextUrl: URL | null }> {
-  const res = await fetch(url.toString());
-  if (!res.ok) throw new Error(`Upstream islands page failed: ${res.status}`);
-
-  const json = (await res.json()) as any;
-  const items = (json.items || json.data || []) as RawIsland[];
-  const next = json.next || json.nextUrl || json.links?.next;
-  let nextUrl: URL | null = null;
-  if (typeof next === 'string') {
+  for (let attempt = 1; attempt <= ISLANDS_PAGE_FETCH_ATTEMPTS; attempt += 1) {
     try {
-      nextUrl = new URL(next, FORTNITE_API_BASE);
-    } catch {
-      nextUrl = null;
+      const res = await fetch(url.toString(), {
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': 'fortnite-island-ranking/1.0'
+        }
+      });
+      if (!res.ok) {
+        if (isRetryableIslandsPageFailure(res.status) && attempt < ISLANDS_PAGE_FETCH_ATTEMPTS) {
+          await sleep(attempt * ISLANDS_PAGE_FETCH_BACKOFF_MS);
+          continue;
+        }
+        throw new Error(`Upstream islands page failed: ${res.status}`);
+      }
+
+      const json = (await res.json()) as any;
+      const items = (json.items || json.data || []) as RawIsland[];
+      const next = json.next || json.nextUrl || json.links?.next;
+      let nextUrl: URL | null = null;
+      if (typeof next === 'string') {
+        try {
+          nextUrl = new URL(next, FORTNITE_API_BASE);
+        } catch {
+          nextUrl = null;
+        }
+      }
+
+      return { items, nextUrl };
+    } catch (error) {
+      if (attempt < ISLANDS_PAGE_FETCH_ATTEMPTS) {
+        await sleep(attempt * ISLANDS_PAGE_FETCH_BACKOFF_MS);
+        continue;
+      }
+      throw error;
     }
   }
 
-  return { items, nextUrl };
+  throw new Error('Upstream islands page failed');
 }
 
 async function crawlAllIslands(maxPages: number, pageSize: number, search?: string): Promise<IslandRecord[]> {
-  const first = new URL('/ecosystem/v1/islands', FORTNITE_API_BASE);
-  first.searchParams.set('limit', String(pageSize));
-  if (search) first.searchParams.set('search', search);
-
   let page = 0;
-  let url: URL | null = first;
+  let url: URL | null = createIslandsUrl(pageSize, search);
   const out: IslandRecord[] = [];
 
   while (url && page < maxPages) {
-    url.searchParams.set('page', String(page + 1));
-    const { items, nextUrl } = await fetchIslandsPage(url);
+    let pageData: { items: RawIsland[]; nextUrl: URL | null };
+    try {
+      pageData = await fetchIslandsPage(url);
+    } catch (error) {
+      if (out.length === 0) {
+        throw error;
+      }
+      console.warn('crawlAllIslands partial failure', {
+        page: page + 1,
+        pageSize,
+        search: search || null,
+        error: String(error)
+      });
+      break;
+    }
 
-    for (const item of items) {
+    for (const item of pageData.items) {
       const island = toIslandRecord(item);
       if (island) out.push(island);
     }
 
     page += 1;
-    if (nextUrl) {
-      url = nextUrl;
-      continue;
-    }
-
-    if (items.length < pageSize) break;
-
-    const guess = new URL('/ecosystem/v1/islands', FORTNITE_API_BASE);
-    guess.searchParams.set('limit', String(pageSize));
-    guess.searchParams.set('page', String(page + 1));
-    if (search) guess.searchParams.set('search', search);
-    url = guess;
+    url = pageData.nextUrl;
   }
 
   return out;
@@ -122,7 +190,11 @@ export async function listIslands(search?: string): Promise<IslandRecord[]> {
 
   const islands = USE_MOCK
     ? await readMockIslands()
-    : await crawlAllIslands(normalizedSearch ? 4 : 8, 100, normalizedSearch && normalizedSearch.length >= 2 ? normalizedSearch : undefined);
+    : await crawlAllIslands(
+        normalizedSearch ? SEARCH_CATALOG_MAX_PAGES : DEFAULT_CATALOG_MAX_PAGES,
+        DEFAULT_CATALOG_PAGE_SIZE,
+        normalizedSearch && normalizedSearch.length >= 2 ? normalizedSearch : undefined
+      );
 
   const filtered = normalizedSearch.length >= 2
     ? islands.filter((item) => item.code.includes(normalizedSearch) || item.name.toLowerCase().includes(normalizedSearch))
@@ -159,30 +231,139 @@ export async function fetchIslandSeries(code: string, window: TimeWindow, metric
 
   const bucketSlug = toBucketSlug(toBucket(window));
   const results = new Map<MetricKey, MetricSeries>();
+  let hadUnexpectedMetricFailure = false;
 
-  await runLimited(normalizedMetrics, 4, async (metric) => {
-    try {
-      const metricSlug = toMetricSlug(metric);
-      const url = new URL(`/ecosystem/v1/islands/${encodeURIComponent(code)}/metrics/${bucketSlug}/${metricSlug}`, FORTNITE_API_BASE);
-      const res = await fetch(url.toString());
-      if (!res.ok) {
+  await runLimited(normalizedMetrics, METRIC_FETCH_CONCURRENCY, async (metric) => {
+    const metricSlug = toMetricSlug(metric);
+    const url = new URL(`/ecosystem/v1/islands/${encodeURIComponent(code)}/metrics/${bucketSlug}/${metricSlug}`, FORTNITE_API_BASE);
+
+    for (let attempt = 1; attempt <= METRIC_FETCH_ATTEMPTS; attempt += 1) {
+      try {
+        const res = await fetch(url.toString(), {
+          headers: {
+            Accept: 'application/json',
+            'User-Agent': 'fortnite-island-ranking/1.0'
+          }
+        });
+        const body = await res.text();
+
+        if (res.ok) {
+          const json = JSON.parse(body) as any;
+          results.set(metric, {
+            metric,
+            points: normalizePoints(json.series || json.data || json.points || json.intervals)
+          });
+          return;
+        }
+
+        const retryable = isRetryableMetricFailure(metric, res.status);
+        if (retryable && attempt < METRIC_FETCH_ATTEMPTS) {
+          await sleep(attempt * 250);
+          continue;
+        }
+
+        if (!EXPECTED_MISSING_METRICS.has(metric) || res.status !== 404) {
+          hadUnexpectedMetricFailure = true;
+          console.warn('fetchIslandSeries upstream failure', {
+            code,
+            window,
+            metric,
+            status: res.status,
+            body: body.slice(0, 120)
+          });
+        }
+
+        results.set(metric, { metric, points: [] });
+        return;
+      } catch (error) {
+        if (attempt < METRIC_FETCH_ATTEMPTS) {
+          await sleep(attempt * 250);
+          continue;
+        }
+
+        hadUnexpectedMetricFailure = true;
+        console.warn('fetchIslandSeries unexpected failure', {
+          code,
+          window,
+          metric,
+          error: String(error)
+        });
+
         results.set(metric, { metric, points: [] });
         return;
       }
-
-      const json = (await res.json()) as any;
-      results.set(metric, {
-        metric,
-        points: normalizePoints(json.series || json.data || json.points || json.intervals)
-      });
-    } catch {
-      results.set(metric, { metric, points: [] });
     }
   });
 
   const output = normalizedMetrics.map((metric) => results.get(metric) || { metric, points: [] });
-  globalCache.set(cacheKey, output, ttlForWindow(window));
+  globalCache.set(cacheKey, output, hadUnexpectedMetricFailure ? SHORT_FAILURE_TTL : ttlForWindow(window));
   return output;
+}
+
+async function scoreIslandsByUniquePlayers(islands: IslandRecord[], window: TimeWindow): Promise<ScoredIsland[]> {
+  const scored = new Array<ScoredIsland>(islands.length);
+
+  await runLimited(islands.map((island, index) => ({ island, index })), POPULAR_SCORE_CONCURRENCY, async ({ island, index }) => {
+    try {
+      const series = await fetchIslandSeries(island.code, window, ['uniquePlayers']);
+      const points = series[0]?.points || [];
+      const latest = points.length > 0 ? (points[points.length - 1]?.value ?? 0) : 0;
+      scored[index] = {
+        island,
+        latest,
+        hasData: points.length > 0
+      };
+    } catch {
+      scored[index] = {
+        island,
+        latest: 0,
+        hasData: false
+      };
+    }
+  });
+
+  return scored;
+}
+
+async function collectCatalogCandidates(limit: number): Promise<IslandRecord[]> {
+  let page = 0;
+  let url: URL | null = createIslandsUrl(POPULAR_SCAN_PAGE_SIZE);
+  const seenCodes = new Set<string>();
+  const islands: IslandRecord[] = [];
+
+  while (url && page < POPULAR_SCAN_MAX_PAGES && islands.length < limit) {
+    let pageData: { items: RawIsland[]; nextUrl: URL | null };
+    try {
+      pageData = await fetchIslandsPage(url);
+    } catch (error) {
+      if (islands.length === 0) {
+        throw error;
+      }
+      console.warn('collectCatalogCandidates page fetch failed', {
+        page: page + 1,
+        limit,
+        error: String(error)
+      });
+      break;
+    }
+
+    for (const item of pageData.items) {
+      const island = toIslandRecord(item);
+      if (!island || seenCodes.has(island.code)) {
+        continue;
+      }
+      seenCodes.add(island.code);
+      islands.push(island);
+      if (islands.length >= limit) {
+        break;
+      }
+    }
+
+    page += 1;
+    url = pageData.nextUrl;
+  }
+
+  return islands;
 }
 
 export async function computePopularIslands(window: TimeWindow, limit: number, search?: string): Promise<IslandRecord[]> {
@@ -191,23 +372,51 @@ export async function computePopularIslands(window: TimeWindow, limit: number, s
   const cached = globalCache.get<IslandRecord[]>(cacheKey);
   if (cached) return cached;
 
-  const islands = await listIslands(normalizedSearch || undefined);
-  const candidates = normalizedSearch ? islands.slice(0, 24) : islands;
-
-  const values = new Map<string, number>();
-  await runLimited(candidates, normalizedSearch ? 4 : 8, async (island) => {
+  if (!normalizedSearch) {
     try {
-      const series = await fetchIslandSeries(island.code, window, ['uniquePlayers']);
-      const points = series[0]?.points || [];
-      const latest = points.length > 0 ? (points[points.length - 1]?.value ?? 0) : 0;
-      values.set(island.code, latest);
-    } catch {
-      values.set(island.code, 0);
+      const islands = await collectCatalogCandidates(limit);
+      const ttl = islands.length >= Math.min(limit, 12) ? ttlForWindow(window) : SHORT_FAILURE_TTL;
+      globalCache.set(cacheKey, islands, ttl);
+      return islands;
+    } catch (error) {
+      console.warn('computePopularIslands upstream failure', {
+        window,
+        limit,
+        search: null,
+        error: String(error)
+      });
+      globalCache.set(cacheKey, [], SHORT_FAILURE_TTL);
+      return [];
     }
-  });
+  }
 
-  const sorted = [...candidates].sort((left, right) => (values.get(right.code) || 0) - (values.get(left.code) || 0));
-  const result = sorted.slice(0, Math.min(limit, sorted.length));
-  globalCache.set(cacheKey, result, ttlForWindow(window));
+  let scored: ScoredIsland[] = [];
+
+  try {
+    const islands = await listIslands(normalizedSearch || undefined);
+    const candidates = islands.slice(0, Math.min(POPULAR_MAX_SCORED_CANDIDATES, 24));
+    scored = await scoreIslandsByUniquePlayers(candidates, window);
+  } catch (error) {
+    console.warn('computePopularIslands upstream failure', {
+      window,
+      limit,
+      search: normalizedSearch || null,
+      error: String(error)
+    });
+  }
+
+  const populated = scored
+    .filter((item) => item.hasData && item.latest > 0)
+    .sort((left, right) => right.latest - left.latest);
+  const empty = scored
+    .filter((item) => !item.hasData || item.latest <= 0)
+    .sort((left, right) => right.latest - left.latest);
+
+  const result = [...populated, ...empty]
+    .slice(0, Math.min(limit, populated.length + empty.length))
+    .map((entry) => entry.island);
+
+  const ttl = populated.length >= Math.min(limit, 12) ? ttlForWindow(window) : SHORT_FAILURE_TTL;
+  globalCache.set(cacheKey, result, ttl);
   return result;
 }

--- a/functions/src/lib/metrics.test.ts
+++ b/functions/src/lib/metrics.test.ts
@@ -16,6 +16,16 @@ describe('metrics helpers', () => {
     ]);
   });
 
+  it('drops upstream points whose value is null', () => {
+    const points = normalizePoints([
+      { ts: '2025-01-01T00:00:00Z', value: 10 },
+      { ts: '2025-01-01T00:10:00Z', value: null },
+      ['2025-01-01T00:20:00Z', null]
+    ]);
+
+    expect(points).toEqual([{ ts: '2025-01-01T00:00:00Z', value: 10 }]);
+  });
+
   it('computes previous-window delta', () => {
     const delta = previousWindowDelta([
       { ts: '2025-01-01T00:00:00Z', value: 10 },

--- a/functions/src/lib/metrics.ts
+++ b/functions/src/lib/metrics.ts
@@ -1,6 +1,6 @@
 import type { DeltaValue, MetricKey, MetricPoint, MetricSeries, MetricSnapshot, TimeWindow } from './contracts.js';
 
-export type Bucket = 'TEN_MINUTE' | 'HOUR' | 'DAY';
+export type Bucket = 'MINUTE' | 'HOUR' | 'DAY';
 
 export const METRIC_LABELS: Record<MetricKey, string> = {
   uniquePlayers: 'Unique Players',
@@ -39,13 +39,13 @@ const METRIC_ALIASES: Record<string, MetricKey> = {
 };
 
 export function toBucket(window: TimeWindow): Bucket {
-  if (window === '10m') return 'TEN_MINUTE';
+  if (window === '10m') return 'MINUTE';
   if (window === '1h') return 'HOUR';
   return 'DAY';
 }
 
-export function toBucketSlug(bucket: Bucket): 'ten-minute' | 'hour' | 'day' {
-  if (bucket === 'TEN_MINUTE') return 'ten-minute';
+export function toBucketSlug(bucket: Bucket): 'minute' | 'hour' | 'day' {
+  if (bucket === 'MINUTE') return 'minute';
   if (bucket === 'HOUR') return 'hour';
   return 'day';
 }
@@ -83,17 +83,19 @@ export function normalizePoints(pointsRaw: unknown): MetricPoint[] {
     .map((point) => {
       if (Array.isArray(point)) {
         const [ts, value] = point;
+        const normalizedValue = value == null ? Number.NaN : Number(value);
         return {
           ts: String(ts ?? ''),
-          value: Number(value ?? 0)
+          value: normalizedValue
         };
       }
 
       if (point && typeof point === 'object') {
         const candidate = point as Record<string, unknown>;
+        const rawValue = candidate.value ?? candidate.v;
         return {
           ts: String(candidate.timestamp ?? candidate.ts ?? candidate.time ?? ''),
-          value: Number(candidate.value ?? candidate.v ?? 0)
+          value: rawValue == null ? Number.NaN : Number(rawValue)
         };
       }
 

--- a/functions/src/lib/warm.test.ts
+++ b/functions/src/lib/warm.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildWarmDashboardUrl, resolveWarmBaseUrl, warmDashboardCaches } from './warm.js';
+
+describe('warm helpers', () => {
+  it('builds public dashboard warm urls on the hosting domain', () => {
+    expect(resolveWarmBaseUrl('demo-project')).toBe('https://demo-project.web.app');
+    expect(buildWarmDashboardUrl('24h', 'https://demo-project.web.app')).toBe(
+      'https://demo-project.web.app/api/dashboard?window=24h'
+    );
+  });
+
+  it('warms every dashboard window through the public url', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200
+    });
+
+    await warmDashboardCaches(fetchMock as never, 'https://demo-project.web.app');
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      'https://demo-project.web.app/api/dashboard?window=10m',
+      'https://demo-project.web.app/api/dashboard?window=1h',
+      'https://demo-project.web.app/api/dashboard?window=24h'
+    ]);
+  });
+});

--- a/functions/src/lib/warm.ts
+++ b/functions/src/lib/warm.ts
@@ -1,0 +1,39 @@
+import fetch from 'node-fetch';
+import { TIME_WINDOWS, type TimeWindow } from './contracts.js';
+
+type FetchLike = typeof fetch;
+
+export function resolveWarmBaseUrl(projectId = process.env.GCLOUD_PROJECT || 'fortnite-island-ranking') {
+  return `https://${projectId.trim()}.web.app`;
+}
+
+export function buildWarmDashboardUrl(window: TimeWindow, baseUrl = resolveWarmBaseUrl()) {
+  const url = new URL('/api/dashboard', baseUrl);
+  url.searchParams.set('window', window);
+  return url.toString();
+}
+
+export async function warmDashboardCaches(fetchImpl: FetchLike = fetch, baseUrl = resolveWarmBaseUrl()) {
+  for (const window of TIME_WINDOWS) {
+    try {
+      const response = await fetchImpl(buildWarmDashboardUrl(window, baseUrl), {
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': 'fortnite-island-ranking-warmer/1.0'
+        }
+      });
+
+      if (!response.ok) {
+        console.warn('warmDashboardCaches request failed', {
+          window,
+          status: response.status
+        });
+      }
+    } catch (error) {
+      console.warn('warmDashboardCaches request failed', {
+        window,
+        error: String(error)
+      });
+    }
+  }
+}

--- a/web/src/lib/urlState.test.tsx
+++ b/web/src/lib/urlState.test.tsx
@@ -43,7 +43,7 @@ describe('urlState', () => {
 
   it('serializes home query state without default values', () => {
     const searchParams = serializeHomeQueryState({
-      window: '10m',
+      window: '24h',
       tab: 'top',
       sort: 'hype',
       query: 'battle',

--- a/web/src/lib/urlState.ts
+++ b/web/src/lib/urlState.ts
@@ -26,7 +26,7 @@ const SORTS: DashboardSort[] = [
 const VIEWS: DashboardView[] = ['table', 'cards'];
 
 export const DEFAULT_HOME_QUERY_STATE: HomeQueryState = {
-  window: '10m',
+  window: '24h',
   tab: 'top',
   sort: 'hype',
   query: '',
@@ -36,11 +36,11 @@ export const DEFAULT_HOME_QUERY_STATE: HomeQueryState = {
 };
 
 export const DEFAULT_DETAIL_QUERY_STATE: DetailQueryState = {
-  window: '10m'
+  window: '24h'
 };
 
 export const DEFAULT_COMPARE_QUERY_STATE: CompareQueryState = {
-  window: '10m',
+  window: '24h',
   codes: []
 };
 

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -21,7 +21,7 @@ import type {
   RecentViewEntry,
   WatchlistEntry
 } from '../lib/types';
-import { toDashboardRequest, useHomeQueryState } from '../lib/urlState';
+import { DEFAULT_HOME_QUERY_STATE, toDashboardRequest, useHomeQueryState } from '../lib/urlState';
 import { DashboardFilterBar } from '../components/DashboardFilterBar';
 import { RankingCards } from '../components/RankingCards';
 import { RankingTable } from '../components/RankingTable';
@@ -284,12 +284,7 @@ export function Home() {
   const resetFilters = () => {
     setSearchInput('');
     setQueryState({
-      window: '10m',
-      tab: 'top',
-      sort: 'hype',
-      query: '',
-      tags: [],
-      creator: '',
+      ...DEFAULT_HOME_QUERY_STATE,
       view: prefersCards ? 'cards' : 'table'
     });
   };


### PR DESCRIPTION
## Summary
- reduce dashboard/search upstream load by trimming the base metric set and simplifying non-search candidate selection
- harden metric/page fetching with better fallbacks, short failure caching, and corrected 10m/minute normalization
- make the dashboard warmer hit the public dashboard URLs so CDN/API cache warming actually affects user traffic

## Validation
- npm test --prefix functions
- npm run build --prefix functions
- local dev-server checks
  - /api/dashboard?window=24h returned populated first-row core metrics in ~9s
  - /api/islands/8696-8732-5741/overview?window=24h returned populated uniquePlayers / peakCcu / favorites / plays / minutesPlayed
- firebase deploy --project fortnite-island-ranking --only functions

## Follow-up
- Fresh cache-busting live origin requests are still partially degraded on Cloud Run and are tracked in #12.
